### PR TITLE
Create Convex projects on chat start

### DIFF
--- a/app/components/chat/Artifact.tsx
+++ b/app/components/chat/Artifact.tsx
@@ -1,7 +1,7 @@
 import { useStore } from '@nanostores/react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { computed } from 'nanostores';
-import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 import { createHighlighter, type BundledLanguage, type BundledTheme, type HighlighterGeneric } from 'shiki';
 import type { ActionState } from '~/lib/runtime/action-runner';
 import { workbenchStore } from '~/lib/stores/workbench';
@@ -14,8 +14,6 @@ import { ConvexDeployTerminal } from '~/components/convex/ConvexDeployTerminal';
 import { api } from '@convex/_generated/api';
 import { useQuery } from 'convex/react';
 import { useChatId } from '~/lib/stores/chat';
-import type { ToolInvocation } from 'ai';
-import { Markdown } from './Markdown';
 
 const highlighterOptions = {
   langs: ['shell'],

--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -27,7 +27,7 @@ import type { ProgressAnnotation } from '~/types/context';
 import type { ActionRunner } from '~/lib/runtime/action-runner';
 import { ConvexConnection } from '~/components/convex/ConvexConnection';
 import { FlexAuthWrapper } from './FlexAuthWrapper';
-
+import { useFlexAuthMode } from '~/lib/stores/convex';
 const TEXTAREA_MIN_HEIGHT = 76;
 
 interface BaseChatProps {
@@ -97,6 +97,7 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
     },
     ref,
   ) => {
+    const flexAuthMode = useFlexAuthMode();
     const TEXTAREA_MAX_HEIGHT = chatStarted ? 400 : 200;
     const [isListening, setIsListening] = useState(false);
     const [recognition, setRecognition] = useState<SpeechRecognition | null>(null);
@@ -444,7 +445,7 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
                           a new line
                         </div>
                       ) : null}
-                      <ConvexConnection />
+                      <ConvexConnection size={flexAuthMode === 'InviteCode' ? 'hidden' : 'small'} />
                     </div>
                   </div>
                 </div>

--- a/app/components/chat/FlexAuthWrapper.tsx
+++ b/app/components/chat/FlexAuthWrapper.tsx
@@ -23,7 +23,7 @@ export function FlexAuthWrapper({ children }: { children: React.ReactNode }) {
     code?: string;
     flexAuthMode: 'InviteCode' | 'ConvexOAuth';
   }>();
-  const { isAuthenticated, isLoading } = useConvexAuth();
+  const { isAuthenticated, isLoading: isConvexAuthLoading } = useConvexAuth();
   useEffect(() => {
     flexAuthModeStore.set(flexAuthMode);
   }, [flexAuthMode]);
@@ -31,7 +31,7 @@ export function FlexAuthWrapper({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (sessionId === undefined) {
       if (flexAuthMode === 'ConvexOAuth') {
-        const isUnauthenticated = !isAuthenticated && !isLoading;
+        const isUnauthenticated = !isAuthenticated && !isConvexAuthLoading;
         if (isUnauthenticated) {
           sessionIdStore.set(null);
         } else if (isAuthenticated) {
@@ -48,7 +48,18 @@ export function FlexAuthWrapper({ children }: { children: React.ReactNode }) {
         });
       }
     }
-  }, [sessionId, isAuthenticated, flexAuthMode, isLoading]);
+  }, [sessionId, isAuthenticated, flexAuthMode, isConvexAuthLoading]);
+
+  const isLoading = sessionId === undefined || flexAuthMode === undefined;
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-4">
+        <div className="i-ph:spinner-gap animate-spin" />
+        Loading...
+      </div>
+    );
+  }
 
   return sessionId === null ? <UnauthenticatedPrompt flexAuthMode={flexAuthMode} /> : children;
 }

--- a/app/components/convex/ConvexConnection.tsx
+++ b/app/components/convex/ConvexConnection.tsx
@@ -7,7 +7,7 @@ import { useChatIdOrNull } from '~/lib/stores/chat';
 import { useQuery, useConvex } from 'convex/react';
 import { api } from '@convex/_generated/api';
 
-export function ConvexConnection({ size = 'small' }: { size?: 'small' | 'full' }) {
+export function ConvexConnection({ size = 'small' }: { size?: 'small' | 'full' | 'hidden' }) {
   const [isOpen, setIsOpen] = useState(false);
   const convexClient = useConvex();
   const sessionId = useConvexSessionIdOrNullOrLoading();
@@ -45,6 +45,11 @@ export function ConvexConnection({ size = 'small' }: { size?: 'small' | 'full' }
       console.error('No sessionId or chatId so cannot disconnect');
     }
   };
+
+  if (size === 'hidden') {
+    // Render no UI, but still have the component so it can handle setting the `convexStore` state
+    return null;
+  }
 
   return (
     <div className="relative">

--- a/app/lib/persistence/useChatHistory.ts
+++ b/app/lib/persistence/useChatHistory.ts
@@ -1,16 +1,13 @@
 import { useLoaderData, useNavigate, useSearchParams } from '@remix-run/react';
 import { useState, useEffect, useRef } from 'react';
 import { atom } from 'nanostores';
-import { useStore } from '@nanostores/react';
 import type { Message } from '@ai-sdk/react';
 import { toast } from 'react-toastify';
 import { useConvex } from 'convex/react';
 import { api } from '@convex/_generated/api';
 import { ConvexError } from 'convex/values';
 import type { SerializedMessage } from '@convex/messages';
-import { getLocalStorage, setLocalStorage } from '~/lib/persistence/localStorage';
-import type { Id } from '@convex/_generated/dataModel';
-import { useConvexSessionIdOrNullOrLoading } from '../stores/convex';
+import { useConvexSessionIdOrNullOrLoading } from '~/lib/stores/convex';
 
 export interface IChatMetadata {
   gitUrl: string;

--- a/convex/convexProjects.ts
+++ b/convex/convexProjects.ts
@@ -2,7 +2,7 @@ import { internalAction, internalMutation, mutation, query } from './_generated/
 import { ConvexError, v } from 'convex/values';
 import { getChatByIdOrUrlIdEnsuringAccess } from './messages';
 import { internal } from './_generated/api';
-import { getCurrentMember } from './sessions';
+import { getCurrentMember, getInviteCode } from './sessions';
 
 export const hasConnectedConvexProject = query({
   args: {
@@ -103,7 +103,8 @@ export const startProvisionConvexProject = mutation({
     }
 
     await ctx.db.patch(chat._id, { convexProject: { kind: 'connecting' } });
-    const projectName = chat.urlId ?? 'demo-project';
+    const inviteCode = await getInviteCode(ctx, { sessionId: args.sessionId });
+    const projectName = chat.urlId ?? inviteCode.code;
     await ctx.scheduler.runAfter(0, internal.convexProjects.connectConvexProject, {
       sessionId: args.sessionId,
       chatId: args.chatId,

--- a/convex/sessions.ts
+++ b/convex/sessions.ts
@@ -232,3 +232,14 @@ export async function getCurrentMember(ctx: QueryCtx) {
   }
   return existingMember;
 }
+
+export async function getInviteCode(ctx: QueryCtx, args: { sessionId: Id<'sessions'> }) {
+  const inviteCode = await ctx.db
+    .query('inviteCodes')
+    .withIndex('bySessionId', (q) => q.eq('sessionId', args.sessionId))
+    .unique();
+  if (inviteCode === null || !inviteCode.isActive) {
+    throw new ConvexError({ code: 'NotAuthorized', message: 'Invite code not found' });
+  }
+  return inviteCode;
+}


### PR DESCRIPTION
Added this to the mutation that starts the chat, conditioned on the session not being associates with a `memberId` (because it must instead be associated with an invite code).

One bit of weirdness is we lose meaningful project names since the `urlId` only gets set once we've streamed in some messages.

`ConvexConnection` still drives syncing the metadata we store to the local state (which the ActionRunner awaits), but just renders no visible UI (this is definitely a hack, but it works).