### PR TITLE
Move Convex setup to webcontainer boot

### DIFF
--- a/app/lib/stores/convex.ts
+++ b/app/lib/stores/convex.ts
@@ -14,17 +14,17 @@ export type ConvexProject = {
 
 export const convexStore = atom<ConvexProject | null>(null);
 
-export function waitForConvexProjectConnection(): Promise<void> {
-  return new Promise<void>((resolve) => {
+export function waitForConvexProjectConnection(): Promise<ConvexProject> {
+  return new Promise((resolve) => {
     if (convexStore.get() !== null) {
-      resolve();
+      resolve(convexStore.get()!);
       return;
     }
 
     const unsubscribe = convexStore.subscribe((project) => {
       if (project !== null) {
         unsubscribe();
-        resolve();
+        resolve(project);
       }
     });
   });

--- a/app/lib/webcontainer/index.ts
+++ b/app/lib/webcontainer/index.ts
@@ -2,6 +2,8 @@ import { WebContainer } from '@webcontainer/api';
 import { WORK_DIR_NAME } from '~/utils/constants';
 import { loadSnapshot } from '~/lib/snapshot';
 import { cleanStackTrace } from '~/utils/stacktrace';
+import { waitForConvexProjectConnection, type ConvexProject } from '../stores/convex';
+import { createScopedLogger } from '~/utils/logger';
 
 interface WebContainerContext {
   loaded: boolean;
@@ -19,6 +21,8 @@ export let webcontainer: Promise<WebContainer> = new Promise(() => {
   // noop for ssr
 });
 
+const logger = createScopedLogger('webcontainer');
+
 if (!import.meta.env.SSR) {
   webcontainer =
     import.meta.hot?.data.webcontainer ??
@@ -35,9 +39,17 @@ if (!import.meta.env.SSR) {
         await loadSnapshot(webcontainer, workbenchStore);
         webcontainerContext.loaded = true;
 
+        logger.info("Waiting for Convex project connection...");
+        const convexProject = await waitForConvexProjectConnection();
+        logger.info("Setting up Convex env vars...");
+        await setupConvexEnvVars(webcontainer, convexProject);
+        logger.info("Initializing Convex Auth...");
+        const { initializeConvexAuth } = await import('../convexAuth');
+        await initializeConvexAuth(convexProject);
+
         // Listen for preview errors
         webcontainer.on('preview-message', (message) => {
-          console.log('WebContainer preview message:', message);
+          logger.info('WebContainer preview message:', message);
 
           // Handle both uncaught exceptions and unhandled promise rejections
           if (message.type === 'PREVIEW_UNCAUGHT_EXCEPTION' || message.type === 'PREVIEW_UNHANDLED_REJECTION') {
@@ -52,16 +64,54 @@ if (!import.meta.env.SSR) {
           }
         });
 
-        console.log('Done booting WebContainer!');
+        logger.info('Done booting WebContainer!');
         (globalThis as any).webcontainer = webcontainer;
         return webcontainer;
       })
       .catch((error) => {
-        console.error('Error booting WebContainer:', error);
+        logger.error('Error booting WebContainer:', error);
         throw error;
       });
 
   if (import.meta.hot) {
     import.meta.hot.data.webcontainer = webcontainer;
+  }
+}
+
+
+async function setupConvexEnvVars(webcontainer: WebContainer, convexProject: ConvexProject) {
+  const { token } = convexProject;
+
+  const envFilePath = '.env.local';
+  const envVarName = 'CONVEX_DEPLOY_KEY';
+  const envVarLine = `${envVarName}=${token}\n`;
+
+  let content: string | null = null;
+  try {
+    content = await webcontainer.fs.readFile(envFilePath, 'utf-8');
+  } catch (err: any) {
+    if (!err.toString().includes('ENOENT')) {
+      throw err;
+    }
+  }
+
+  if (content === null) {
+    // Create the file if it doesn't exist
+    await webcontainer.fs.writeFile(envFilePath, envVarLine);
+    logger.debug('Created .env.local with Convex token');
+  } else {
+    const lines = content.split('\n');
+
+    // Check if the env var already exists
+    const envVarExists = lines.some((line) => line.startsWith(`${envVarName}=`));
+
+    if (!envVarExists) {
+      // Add the env var to the end of the file
+      const newContent = content.endsWith('\n') ? `${content}${envVarLine}` : `${content}\n${envVarLine}`;
+      await webcontainer.fs.writeFile(envFilePath, newContent);
+      logger.debug('Added Convex token to .env.local');
+    } else {
+      logger.debug('Convex token already exists in .env.local');
+    }
   }
 }


### PR DESCRIPTION
We now fully have Convex setup whenever the webcontainer is accessed, so it's ~impossible to get into a state where `npx convex dev` gets stuck! 

<img width="1912" alt="image" src="https://github.com/user-attachments/assets/76e62abf-2620-41af-8add-5a47c6ba7f12" />