### PR TITLE
fix snapshot getting clobbered by uploading template

### DIFF
--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -101,7 +101,7 @@ export class WorkbenchStore {
 
   async downloadSnapshot(id?: string) {
     const snapshotUrl = await this.snapshotUrl(id);
-      // Download the snapshot from Convex
+    // Download the snapshot from Convex
     const resp = await fetch(snapshotUrl);
     if (!resp.ok) {
       throw new Error(`Failed to download snapshot (${resp.statusText}): ${resp.statusText}`);
@@ -212,9 +212,6 @@ export class WorkbenchStore {
         },
       );
     })();
-
-    // Initial snapshot
-    await handleUploadSnapshot();
 
     return () => {
       if (debounceTimeout) {


### PR DESCRIPTION
When you closed a tab and reopened it, the webcontainer downloads the template first, and then would upload a new snapshot with that template, clobbering the existing snapshot. Now we skip the initial upload. Uploading snapshots are triggered by file changes anyway so it was unnecessary.