### PR TITLE
Specify how to import authTables

### DIFF
--- a/app/lib/common/prompts/system.ts
+++ b/app/lib/common/prompts/system.ts
@@ -74,7 +74,7 @@ file.
 This file contains the schema for the Convex backend. It starts with just 'authTables' for setting
 up authentication. ONLY modify the 'applicationTables' object in this file: Do NOT modify the
 'authTables' object. Always include \`...authTables\` in the \`defineSchema\` call when modifying
-this file.
+this file. The \`authTables\` object is imported with \`import { authTables } from "@convex-dev/auth/server";\`.
 </file>
 
 <file path="src/App.tsx">


### PR DESCRIPTION
To prevent 
```
✖ TypeScript typecheck via `tsc` failed.
To ignore failing typecheck, use `--typecheck=disable`.
convex/schema.ts:3:10 - error TS2305: Module '"./auth"' has no exported member 'authTables'.

3 import { authTables } from "./auth";
           ~~~~~~~~~~

Found 1 error in convex/schema.ts:3
⠙ Collecting TypeScript errors

```
on the initial schema.ts change