### PR TITLE
Don't lock scrolling during streaming

### DIFF
--- a/app/components/workbench/Workbench.client.tsx
+++ b/app/components/workbench/Workbench.client.tsx
@@ -76,6 +76,14 @@ export const Workbench = memo(({ chatStarted, isStreaming }: WorkspaceProps) => 
   }, [files]);
 
   const onEditorChange = useCallback<OnEditorChange>((update) => {
+    // This is called debounced, so it's not fair to use it to update
+    // the current doc: we don't actually know which files it's for!
+
+    if (currentDocument?.filePath !== update.filePath) {
+      console.log('onEditorChange fired for what is no longer the current document');
+      return;
+    }
+
     workbenchStore.setCurrentDocumentContent(update.content);
   }, []);
 
@@ -84,6 +92,7 @@ export const Workbench = memo(({ chatStarted, isStreaming }: WorkspaceProps) => 
   }, []);
 
   const onFileSelect = useCallback((filePath: string | undefined) => {
+    workbenchStore.followingStreamedCode.set(false);
     workbenchStore.setSelectedFile(filePath);
   }, []);
 

--- a/app/lib/stores/editor.ts
+++ b/app/lib/stores/editor.ts
@@ -11,6 +11,7 @@ export class EditorStore {
 
   selectedFile: SelectedFile = import.meta.hot?.data.selectedFile ?? atom<string | undefined>();
   documents: MapStore<EditorDocuments> = import.meta.hot?.data.documents ?? map({});
+  followingStreamedCode = atom<boolean>(true);
 
   currentDocument = computed([this.documents, this.selectedFile], (documents, selectedFile) => {
     if (!selectedFile) {

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -55,6 +55,8 @@ export class WorkbenchStore {
 
   artifacts: Artifacts = import.meta.hot?.data.artifacts ?? map({});
 
+  _lastChangedFile: number = 0;
+
   showWorkbench: WritableAtom<boolean> = import.meta.hot?.data.showWorkbench ?? atom(false);
   currentView: WritableAtom<WorkbenchViewType> = import.meta.hot?.data.currentView ?? atom('code');
   unsavedFiles: WritableAtom<Set<string>> = import.meta.hot?.data.unsavedFiles ?? atom(new Set<string>());
@@ -75,6 +77,19 @@ export class WorkbenchStore {
 
     this.#convexClient = new ConvexHttpClient(import.meta.env.VITE_CONVEX_URL!);
     this.startBackup();
+  }
+
+  get followingStreamedCode() {
+    return this.#editorStore.followingStreamedCode;
+  }
+
+  get justChangedFiles(): boolean {
+    const now = Date.now();
+    const close = 300;
+    return now - this._lastChangedFile < close;
+  }
+  setLastChangedFile(): void {
+    this._lastChangedFile = Date.now();
   }
 
   async snapshotUrl(id?: string) {
@@ -368,6 +383,7 @@ export class WorkbenchStore {
   }
 
   setSelectedFile(filePath: string | undefined) {
+    this.setLastChangedFile();
     this.#editorStore.setSelectedFile(filePath);
   }
 
@@ -533,11 +549,12 @@ export class WorkbenchStore {
       const fullPath = path.join(wc.workdir, data.action.filePath);
 
       if (this.selectedFile.value !== fullPath) {
-        this.setSelectedFile(fullPath);
-      }
-
-      if (this.currentView.value !== 'code') {
-        this.currentView.set('code');
+        // Consider focusing the streaming tab so user can see code flowing in.
+        const selectedView = workbenchStore.currentView.value;
+        const followingStreamedCode = workbenchStore.followingStreamedCode.get();
+        if (selectedView === 'code' && followingStreamedCode) {
+          this.setSelectedFile(fullPath);
+        }
       }
 
       const doc = this.#editorStore.documents.get()[fullPath];
@@ -546,11 +563,16 @@ export class WorkbenchStore {
         await artifact.runner.runAction(data, isStreaming);
       }
 
-      this.#editorStore.updateFile(fullPath, data.action.content);
+      // Where does this initial newline come from? The tool parsing incorrectly?
+      const newContent = data.action.content.trimStart();
+
+      this.#editorStore.updateFile(fullPath, newContent);
 
       if (!isStreaming) {
         await artifact.runner.runAction(data);
         this.resetAllFileModifications();
+        // hack, sometimes this isn't cleared
+        //setTimeout(() => this.resetAllFileModifications(), 10);
       }
     } else {
       await artifact.runner.runAction(data);


### PR DESCRIPTION
There's global state that stores the scroll position for every file. This is intended to be used to restore scroll position when you change files, but was inadvertently being triggered every time the document content updated during streaming.

This is a problem because the saved document scroll position is updated with a delay, and certainly not on every scroll event. This meant most scrolls were immediately overwritten causing scroll offset to quickly bounce back.

Now a streamed-to file is only becomes active in the CodeMirror editor when the code panel is open and the user has never clicked another file in the file tree.

This does not yet scroll down automatically to see code being generated below the fold.