### PR TITLE
Make the text box fully focusable when empty

### DIFF
--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -314,9 +314,10 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
                         />
                       )}
                     </ClientOnly>
-                    <div className="flex justify-between items-center text-sm p-4 pt-2">
-                      <div></div>
-                      {input.length > 3 ? (
+                    {input.length > 3 ? (
+                      <div className="flex justify-between items-center text-sm p-4 pt-2">
+                        <div></div>
+
                         <div className="text-xs text-bolt-elements-textTertiary">
                           <KeyboardShortcut
                             value={['Shift', 'Return']}
@@ -324,9 +325,9 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
                           />{' '}
                           for new line
                         </div>
-                      ) : null}
-                      <ConvexConnection size={flexAuthMode === 'InviteCode' ? 'hidden' : 'small'} />
-                    </div>
+                        <ConvexConnection size={flexAuthMode === 'InviteCode' ? 'hidden' : 'small'} />
+                      </div>
+                    ) : null}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Since we don't always have a bottom bar (because we removed the prompt enhance button which was the last remaining button), we should avoid having a part of the visible “text box area” that isn’t clickable

This makes the empty state a little bit smaller, I think it's fine

![image](https://github.com/user-attachments/assets/02399fd5-3e54-4c93-971e-ab494ac74ec5)
