### PR TITLE
Change NPM install to take in a string

### DIFF
--- a/app/components/chat/ToolCall.tsx
+++ b/app/components/chat/ToolCall.tsx
@@ -353,7 +353,7 @@ function toolTitle(invocation: ConvexToolInvocation): React.ReactNode {
       } else {
         try {
           const args = npmInstallToolParameters.parse(invocation.args);
-          return <span className="font-mono text-sm">{`npm i ${args.packages.join(' ')}`}</span>;
+          return <span className="font-mono text-sm">{`npm i ${args.packages}`}</span>;
         } catch (error: unknown) {
           if (invocation.state === 'result') {
             invocation.result = `Error: Could not parse arguments ${error}`;

--- a/app/lib/runtime/action-runner.ts
+++ b/app/lib/runtime/action-runner.ts
@@ -370,7 +370,7 @@ export class ActionRunner {
             const args = npmInstallToolParameters.parse(parsed.args);
             const container = await this.#webcontainer;
             await waitForContainerBootState(ContainerBootState.READY);
-            const npmInstallProc = await container.spawn('npm', ['install', ...args.packages]);
+            const npmInstallProc = await container.spawn('npm', ['install', ...args.packages.split(' ')]);
             action.abortSignal.addEventListener('abort', () => {
               npmInstallProc.kill();
             });
@@ -397,10 +397,11 @@ export class ActionRunner {
             );
             this.terminalOutput.set(output);
             const npmInstallExitCode = await Promise.race([promise, npmInstallProc.exit]);
+            const cleanedOutput = cleanConvexOutput(output);
             if (npmInstallExitCode !== 0) {
-              throw new Error(`Npm install failed with exit code ${npmInstallExitCode}: ${output}`);
+              throw new Error(`Npm install failed with exit code ${npmInstallExitCode}: ${cleanedOutput}`);
             }
-            result = output;
+            result = cleanedOutput;
           } catch (error: unknown) {
             if (error instanceof z.ZodError) {
               result = `Error: Invalid npm install arguments.  ${error}`;
@@ -476,6 +477,8 @@ const BANNED_LINES = [
   'transforming (',
   'computing gzip size',
   'Collecting TypeScript errors',
+  'idealTree buildDeps',
+  'timing reify:unpack'
 ];
 
 // Cleaning terminal output helps the agent focus on the important parts and

--- a/app/lib/runtime/npmInstallTool.ts
+++ b/app/lib/runtime/npmInstallTool.ts
@@ -1,9 +1,24 @@
 import type { Tool } from 'ai';
 import { z } from 'zod';
 
-const npmInstallToolDescription = `Install additional dependencies for the project with npm.`;
+export const npmInstallToolDescription = `
+Install additional dependencies for the project with NPM.
+
+Choose high quality, flexible libraries that are well-maintained and have
+significant adoption. Always use libraries that have TypeScript definitions.
+`;
+
+const packagesDescription = `
+Space separated list of NPM packages to install. This will be passed directly to \`npm install\`.
+
+Examples:
+- 'date-fns'
+- 'chart.js react-chartjs-2'
+- 'motion'
+`;
+
 export const npmInstallToolParameters = z.object({
-  packages: z.array(z.string()),
+  packages: z.string().describe(packagesDescription),
 });
 
 export const npmInstallTool: Tool = {


### PR DESCRIPTION
I think the models just aren't good at generating nested objects for tool calls -- we should probably just stick to objects with primitive values.

This is technically backwards incompatible but I think us catching invalid argument errors should make it ~fine?