### PR TITLE
Record cached tokens to opentelemetry

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -4,7 +4,7 @@ import { useChat } from '@ai-sdk/react';
 import { useAnimate } from 'framer-motion';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useMessageParser, useShortcuts, useSnapScroll } from '~/lib/hooks';
-import { description, useChatHistoryConvex } from '~/lib/persistence';
+import { chatIdStore, description, useChatHistoryConvex } from '~/lib/persistence';
 import { chatStore, useChatIdOrNull } from '~/lib/stores/chat';
 import { workbenchStore } from '~/lib/stores/workbench';
 import { DEFAULT_MODEL, DEFAULT_PROVIDER, PROMPT_COOKIE_KEY, PROVIDER_LIST } from '~/utils/constants';
@@ -147,9 +147,11 @@ export const ChatImpl = memo(({ description, initialMessages, storeMessageHistor
     api: '/api/chat',
     sendExtraMessageFields: true,
     experimental_prepareRequestBody: ({ messages }) => {
+      const chatId = chatIdStore.get() ?? "";
       return {
         messages: chatContextManager.current.prepareContext(messages),
         firstUserMessage: messages.filter((message) => message.role == 'user').length == 1,
+        chatId,
       };
     },
     maxSteps: 64,

--- a/app/lib/.server/llm/convex-agent.ts
+++ b/app/lib/.server/llm/convex-agent.ts
@@ -16,13 +16,14 @@ import { viewTool } from '~/lib/runtime/viewTool';
 import type { ConvexToolSet } from '~/lib/common/types';
 import { npmInstallTool } from '~/lib/runtime/npmInstallTool';
 import { openai } from '@ai-sdk/openai';
+import type { Tracer } from '~/routes/api.chat';
+import type { Span } from '@opentelemetry/api';
 
 export type AITextDataStream = ReturnType<typeof createDataStream>;
 
 export type Provider = {
   maxTokens: number;
   model: LanguageModelV1;
-  systemPrompt?: string;
 };
 
 export type RequestProgress = {
@@ -36,7 +37,7 @@ const tools: ConvexToolSet = {
   npmInstall: npmInstallTool,
 };
 
-export async function convexAgent(env: Env, firstUserMessage: boolean, messages: Messages): Promise<AITextDataStream> {
+export async function convexAgent(chatId: string, env: Env, firstUserMessage: boolean, messages: Messages, tracer: Tracer | null): Promise<AITextDataStream> {
   const progress: RequestProgress = {
     counter: 1,
     cumulativeUsage: {
@@ -60,7 +61,6 @@ export async function convexAgent(env: Env, firstUserMessage: boolean, messages:
         provider = {
           model: openai(model),
           maxTokens: 8192,
-          systemPrompt: [roleSystemPrompt, constantPrompt].join('\n'),
         };
       } else {
         const anthropic = createAnthropic({
@@ -85,18 +85,25 @@ export async function convexAgent(env: Env, firstUserMessage: boolean, messages:
       const result = streamText({
         model: provider.model,
         maxTokens: provider.maxTokens,
-        system: provider.systemPrompt,
-
-        // NB: We will prepend system messages (with the appropriate cache control headers)
-        // in our custom fetch implementation hooked in above.
-        messages: cleanupAssistantMessages(messages),
+        messages: [
+          {
+            role: 'system',
+            content: roleSystemPrompt,
+          },
+          {
+            role: 'system',
+            content: constantPrompt,
+          },
+          ...cleanupAssistantMessages(messages),
+        ],
         tools,
-        onFinish: (result) => onFinishHandler(dataStream, progress, result),
+        onFinish: (result) => onFinishHandler(dataStream, progress, result, tracer, chatId),
 
         experimental_telemetry: {
           isEnabled: true,
           metadata: {
             firstUserMessage,
+            chatId,
           },
         },
       });
@@ -133,24 +140,25 @@ function anthropicInjectCacheControl(guidelinesPrompt: string, options?: Request
   if (typeof options.body !== 'string') {
     throw new Error('Body must be a string');
   }
-  const startChars = options.body.length;
+
   const body = JSON.parse(options.body);
-  body.system = [
-    {
-      type: 'text',
-      text: roleSystemPrompt,
-    },
-    {
-      type: 'text',
-      text: guidelinesPrompt,
-      cache_control: { type: 'ephemeral' },
-    },
-    // NB: The client dynamically manages files injected as context
-    // past this point, and we don't want them to pollute the cache.
-    ...(body.system ?? []),
-  ];
+
+  if (body.system.length < 2) {
+    throw new Error('Body must contain at least two system messages');
+  }
+  if (body.system[0].text !== roleSystemPrompt) {
+    throw new Error('First system message must be the roleSystemPrompt');
+  }
+  if (body.system[1].text !== constantPrompt) {
+    throw new Error('Second system message must be the constantPrompt');
+  }
+
+  // Inject the cache control header after the constant prompt, but leave
+  // the dynamic system prompts uncached.
+  body.system[1].cache_control = { type: 'ephemeral' };
+
   const newBody = JSON.stringify(body);
-  console.log(`Injected system messages in ${Date.now() - start}ms (${startChars} -> ${newBody.length} chars)`);
+  console.log(`Injected system messages in ${Date.now() - start}ms`);
   return { ...options, body: newBody };
 }
 
@@ -172,6 +180,8 @@ async function onFinishHandler(
   dataStream: DataStreamWriter,
   progress: RequestProgress,
   result: Omit<StepResult<any>, 'stepType' | 'isContinued'>,
+  tracer: Tracer | null,
+  chatId: string,
 ) {
   const { usage } = result;
   console.log('Finished streaming', {
@@ -183,6 +193,22 @@ async function onFinishHandler(
     progress.cumulativeUsage.completionTokens += usage.completionTokens || 0;
     progress.cumulativeUsage.promptTokens += usage.promptTokens || 0;
     progress.cumulativeUsage.totalTokens += usage.totalTokens || 0;
+  }
+  if (tracer) {
+    const span = tracer.startSpan('on-finish-handler');
+    span.setAttribute('chatId', chatId);
+    span.setAttribute('finishReason', result.finishReason);
+    span.setAttribute('usage.completionTokens', usage?.completionTokens || 0);
+    span.setAttribute('usage.promptTokens', usage?.promptTokens || 0);
+    span.setAttribute('usage.totalTokens', usage?.totalTokens || 0);
+    if (result.providerMetadata) {
+      const anthropic: any = result.providerMetadata.anthropic;
+      if (anthropic) {
+        span.setAttribute('providerMetadata.anthropic.cacheCreationInputTokens', anthropic.cacheCreationInputTokens);
+        span.setAttribute('providerMetadata.anthropic.cacheReadInputTokens', anthropic.cacheReadInputTokens);
+      }
+    }
+    span.end();
   }
   dataStream.writeMessageAnnotation({
     type: 'usage',


### PR DESCRIPTION
This is pretty hax, but we're logging a custom span with the cached token stats.

see  https://app.axiom.co/convex-aqen/dashboards/otel.traces.flex?spanId=cbe27ac6f9109bdd&traceDataset=flex&traceEnd=2025-04-05T18%3A29%3A41-04%3A00&traceId=23338e23e70ee47a1e31e1b42ca0a5ab&traceStart=2025-04-05T18%3A24%3A41-04%3A00&v_operation_name=on-finish-handler&v_service_name=unknown_service%3Anode&v_status_name= for an example

- usage.promptTokens : uncached input tokens
- providerMetadata.anthropic.cacheCreationInputTokens : writes to cache
- providerMetadata.anthropic.cacheReadInputTokens : reads from cache
- usage.completionTokens : output tokens
