### PR TITLE
Tweaks to oauth project connection flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ There are two forms of auth, dictated by the `FLEX_AUTH_MODE` environment variab
 
 - Users sign in with their Github account to Convex (as of writing, actually a test Convex Auth0 app)
 - Users go through an OAuth flow to link projects in their account to Flex
+- You'll need `CONVEX_OAUTH_CLIENT_ID` + `CONVEX_OAUTH_CLIENT_SECRET` set in your `.env.local` (values are in 1Password under `flex .env.local`)
 
 # Working on the template
 

--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -314,7 +314,7 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
                           for new line
                         </div>
                       ) : null}
-                      <ConvexConnection size={flexAuthMode === 'InviteCode' ? 'hidden' : 'small'} />
+                      {chatStarted && flexAuthMode === 'ConvexOAuth' && <ConvexConnection size="small" />}
                     </div>
                   </div>
                 </div>

--- a/app/components/convex/ConvexConnection.tsx
+++ b/app/components/convex/ConvexConnection.tsx
@@ -8,14 +8,10 @@ import { useQuery, useConvex } from 'convex/react';
 import { api } from '@convex/_generated/api';
 import { useStore } from '@nanostores/react';
 
-export function ConvexConnection({ size = 'small' }: { size?: 'small' | 'full' | 'hidden' }) {
+export function ConvexConnection({ size = 'small' }: { size?: 'small' | 'full' }) {
   const [isDesiredOpen, setIsOpen] = useState(false);
 
   const chatStarted = useStore(chatStore).started;
-  const connected = !useStore(convexStore);
-  const forceOpen = useStore(flexAuthModeStore) === 'ConvexOAuth' && connected && chatStarted;
-  const isOpen = isDesiredOpen || forceOpen;
-  const forcedOpen = forceOpen && !isDesiredOpen;
 
   const convexClient = useConvex();
   const sessionId = useConvexSessionIdOrNullOrLoading();
@@ -42,6 +38,10 @@ export function ConvexConnection({ size = 'small' }: { size?: 'small' | 'full' |
 
   const isConnected = projectInfo !== null;
 
+  const forceOpen = useStore(flexAuthModeStore) === 'ConvexOAuth' && !isConnected && chatStarted;
+  const isOpen = isDesiredOpen || forceOpen;
+  const forcedOpen = forceOpen && !isDesiredOpen;
+
   const handleDisconnect = async () => {
     convexStore.set(null);
     if (sessionId && chatId) {
@@ -53,11 +53,6 @@ export function ConvexConnection({ size = 'small' }: { size?: 'small' | 'full' |
       console.error('No sessionId or chatId so cannot disconnect');
     }
   };
-
-  if (size === 'hidden') {
-    // Render no UI, but still have the component so it can handle setting the `convexStore` state
-    return null;
-  }
 
   return (
     <div className="relative">
@@ -83,7 +78,7 @@ export function ConvexConnection({ size = 'small' }: { size?: 'small' | 'full' |
 
       <DialogRoot open={isOpen} onOpenChange={setIsOpen}>
         {isOpen && (
-          <Dialog className="max-w-[520px] p-6">
+          <Dialog className="max-w-[520px] p-6" showCloseButton={!forcedOpen}>
             <div className="space-y-4">
               <DialogTitle>
                 <div className="flex items-center gap-2 px-3">
@@ -124,11 +119,15 @@ export function ConvexConnection({ size = 'small' }: { size?: 'small' | 'full' |
                   </div>
                 )}
               </div>
-              <div className="flex justify-end gap-2 mt-6 px-3">
-                <DialogClose asChild>
-                  <DialogButton type="secondary">Close</DialogButton>
-                </DialogClose>
-              </div>
+              {!forcedOpen && (
+                <div className="flex justify-end gap-2 mt-6 px-3">
+                  <DialogClose asChild>
+                    <DialogButton type="secondary" onClick={() => setIsOpen(false)}>
+                      Close
+                    </DialogButton>
+                  </DialogClose>
+                </div>
+              )}
             </div>
           </Dialog>
         )}

--- a/convex/convexProjects.ts
+++ b/convex/convexProjects.ts
@@ -101,6 +101,17 @@ export const startProvisionConvexProject = mutation({
     if (!chat) {
       throw new ConvexError({ code: 'NotAuthorized', message: 'Chat not found' });
     }
+    const session = await ctx.db.get(args.sessionId);
+    if (!session) {
+      console.error(`Session not found: ${args.sessionId}`);
+      throw new ConvexError({ code: 'NotAuthorized', message: 'Chat not found' });
+    }
+    if (session.memberId !== undefined) {
+      console.error(
+        `This flow is only available with invite codes but is being used for the oauth flow: ${args.sessionId}`,
+      );
+      throw new ConvexError({ code: 'NotAuthorized', message: 'Invalid flow for connecting a project' });
+    }
 
     await ctx.db.patch(chat._id, { convexProject: { kind: 'connecting' } });
     const inviteCode = await getInviteCode(ctx, { sessionId: args.sessionId });


### PR DESCRIPTION
* Fixes to session handling specifically when switching from a valid `InviteCode` session to the `ConvexOAuth` mode
* Stopped showing the dialog close + close button when we were forcing the dialog open
* Stopped showing the connection button on the initial screen (we can bring this back if we want it there too, but need to update the logic)