### PR TITLE
Update readme to favor the Convex OAuth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,22 @@ pnpx convex dev
 
 There are two forms of auth, dictated by the `FLEX_AUTH_MODE` environment variable.
 
+#### `FLEX_AUTH_MODE=ConvexOAuth`
+
+- Users sign in with their Github account to Convex (as of writing, actually a test Convex Auth0 app)
+- Users go through an OAuth flow to link projects in their account to Flex
+- You'll need the following env vars set in `.env.local` (values are in 1Password under `flex .env.local`)
+  - `VITE_AUTH0_CLIENT_ID`
+  - `VITE_AUTH0_DOMAIN`
+  - `CONVEX_OAUTH_CLIENT_ID`
+  - `CONVEX_OAUTH_CLIENT_SECRET`
+
 #### `FLEX_AUTH_MODE=InviteCode`
 
 - Convex projects are provisioned automatically against one of our teams
 - The credentials are saved as default environment variables on the `bolt-diy-f612` Convex project
 - You need a "code" to access Flex. There's an internal mutation you can run to issue yourself a code (e.g. `sshader-test`).
 - Each code corresponds to a user, so if you're doing this in production, issue a code with your name in it.
-
-#### `FLEX_AUTH_MODE=ConvexOAuth`
-
-- Users sign in with their Github account to Convex (as of writing, actually a test Convex Auth0 app)
-- Users go through an OAuth flow to link projects in their account to Flex
-- You'll need `CONVEX_OAUTH_CLIENT_ID` + `CONVEX_OAUTH_CLIENT_SECRET` set in your `.env.local` (values are in 1Password under `flex .env.local`)
 
 # Working on the template
 


### PR DESCRIPTION
...and the requisite testing that this works in dev + preview. Leaving prod using `InviteCode` for now.