### PR TITLE
move snapshot back to r2, test cache bust

### DIFF
--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -95,7 +95,9 @@ export class WorkbenchStore {
   }
 
   async snapshotUrl(id?: string) {
-    const SNAPSHOT_URL = 'https://static.convex.dev/chef/snapshot.bin';
+    const COMMIT_SHA = process.env.VERCEL_GIT_COMMIT_SHA ?? null;
+    const SNAPSHOT_URL =
+      'https://chef-static.convex.app/snapshot.bin' + (COMMIT_SHA ? `?v=${COMMIT_SHA.substring(0, 5)}` : '');
     if (!id) {
       console.log('No chat id yet, downloading from Convex');
       return SNAPSHOT_URL;


### PR DESCRIPTION
move the snapshot back to R2 + rudimentary cache busting once we're on vercel

looks like cloudflare sends back headers that appropriately allow the browser to cache the snapshot even though it's >50MB! so my thinking that this was uncacheable was false, it was just cloudfront