### PR TITLE
Ignore edits to node_modules for triggering snapshots

### DIFF
--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -208,6 +208,7 @@ export class WorkbenchStore {
     let debounceTimeout: NodeJS.Timeout | undefined;
     const debouncedUploadSnapshot = () => {
       this.saveState.set('saving');
+      console.log('debouncedUploadSnapshot hasTimeout', debounceTimeout);
       if (debounceTimeout) {
         clearTimeout(debounceTimeout);
       }
@@ -226,7 +227,10 @@ export class WorkbenchStore {
           recursive: true,
           persistent: true,
         },
-        () => {
+        (_event, filename) => {
+          if (typeof filename === 'string' && filename.startsWith('node_modules/')) {
+            return;
+          }
           debouncedUploadSnapshot();
         },
       );


### PR DESCRIPTION
I noticed I couldn't close tabs even before I started a chat and the file changes that triggered this were all to `node_modules` (I think all the executables). So filtering them out so they don't trigger the upload + don't trigger the beforeunload.