### PR TITLE
Partially revert context size increase

### DIFF
--- a/app/lib/ChatContextManager.ts
+++ b/app/lib/ChatContextManager.ts
@@ -13,10 +13,10 @@ import { viewParameters } from './runtime/viewTool';
 
 // It's wasteful to actually tokenize the content, so we'll just use character
 // counts as a heuristic.
-const MAX_RELEVANT_FILES_SIZE = 16384;
-const MAX_RELEVANT_FILES = 32;
+const MAX_RELEVANT_FILES_SIZE = 8192;
+const MAX_RELEVANT_FILES = 16;
 
-const MAX_COLLAPSED_MESSAGES_SIZE = 16384;
+const MAX_COLLAPSED_MESSAGES_SIZE = 8192;
 
 type UIMessagePart = UIMessage['parts'][number];
 


### PR DESCRIPTION
I turned up files size from 8192 -> 16384 and messages size from 4096 to 16384 last weekend.

I suspect this is part of what's making the model dumber, so let's turn these back down. We don't need as much context if we're not using the view/edit tool (which are currently disabled)