### PR TITLE
Add ASCII restriction to field name guidelines

### DIFF
--- a/app/lib/common/prompts/convexGuidelines.ts
+++ b/app/lib/common/prompts/convexGuidelines.ts
@@ -195,6 +195,9 @@ To keep performance fast, Convex puts limits on function calls and database reco
 - Queries, mutations, and actions can return at most 8 MiB of data as their return value.
 
 - Arrays in arguments, database records, and return values can have at most 8192 elements.
+- Objects in function arguments and return values must be valid Convex objects, so they can
+  only contain ASCII field names. ALWAYS remap non-ASCII characters like emoji to an
+  ASCII code before storing them in an object synced to Convex.
 - Objects and arrays can only be nested up to depth 16.
 - Database records must be smaller than 1MiB.
 


### PR DESCRIPTION
I'm not sure if this is enough to consistently get the model to not use a Record with emoji as keys for the reactions in the chat app, but it's worth a shot