### PR TITLE
Add a access gate screen between signing in + using chef

### DIFF
--- a/app/lib/stores/convex.ts
+++ b/app/lib/stores/convex.ts
@@ -145,6 +145,47 @@ function removeCodeFromUrl() {
   window.history.replaceState({}, '', url);
 }
 
+const VALID_ACCESS_CODE_KEY = 'validAccessCodeSessionId';
+
+export async function setValidAccessCode(convex: ConvexReactClient, code: string | null): Promise<boolean> {
+  const existing = getLocalStorage(VALID_ACCESS_CODE_KEY);
+  if (existing) {
+    let isValidSession: boolean = false;
+    try {
+      isValidSession = await convex.query(api.sessions.verifySession, {
+        sessionId: existing as Id<'sessions'>,
+        flexAuthMode: 'InviteCode',
+      });
+    } catch (_error) {
+      setLocalStorage(VALID_ACCESS_CODE_KEY, null);
+      return false;
+    }
+    if (isValidSession) {
+      setLocalStorage(VALID_ACCESS_CODE_KEY, existing);
+      return true;
+    }
+    setLocalStorage(VALID_ACCESS_CODE_KEY, null);
+    return false;
+  }
+  if (code === null) {
+    setLocalStorage(VALID_ACCESS_CODE_KEY, null);
+    return false;
+  }
+  let sessionId: Id<'sessions'> | null = null;
+  try {
+    sessionId = await convex.mutation(api.sessions.getSession, { code });
+  } catch (_error) {
+    setLocalStorage(VALID_ACCESS_CODE_KEY, null);
+    return false;
+  }
+  if (sessionId) {
+    setLocalStorage(VALID_ACCESS_CODE_KEY, sessionId);
+    return true;
+  }
+  setLocalStorage(VALID_ACCESS_CODE_KEY, null);
+  return false;
+}
+
 const SELECTED_TEAM_SLUG_KEY = 'selectedConvexTeamSlug';
 export const selectedTeamSlugStore = atom<string | null>(null);
 


### PR DESCRIPTION
Re-using the invite codes, but not for their intended purpose. Now folks who sign in will get a screen asking for an invite code. If they've previously entered a valid code, they will skip this step.

In this case, we're not using the invite codes as user identity (that's coming from the auth with convex.dev), but instead using it as a basic UI gate.