### PR TITLE
Fix issue with alerts not triggering messages

### DIFF
--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -135,7 +135,7 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
                       alert={actionAlert}
                       clearAlert={() => clearAlert?.()}
                       postMessage={(message) => {
-                        sendMessage?.({} as any, message);
+                        handleSendMessage?.({} as any, message);
                         clearAlert?.();
                       }}
                     />


### PR DESCRIPTION
We changed `sendMessage` to have a second arg and tsc didn't catch this callsite.