### PR TITLE
Prevent empty string code

### DIFF
--- a/app/components/chat/Chat.tsx
+++ b/app/components/chat/Chat.tsx
@@ -154,7 +154,8 @@ export const Chat = memo(({ initialMessages, storeMessageHistory, initializeChat
   }, [containerBootState]);
 
   useEffect(() => {
-    const prompt = searchParams.get('prompt');
+    // an empty string code is confusing, consider it no code
+    const prompt = searchParams.get('prompt') || null;
 
     if (!prompt) {
       return;

--- a/app/components/chat/FlexAuthWrapper.tsx
+++ b/app/components/chat/FlexAuthWrapper.tsx
@@ -90,7 +90,7 @@ function UnauthenticatedPrompt({ flexAuthMode }: { flexAuthMode: 'InviteCode' | 
 }
 
 function AccessGateForm({ setHasValidCode }: { setHasValidCode: (hasValidCode: boolean) => void }) {
-  const [code, setCode] = useState('');
+  const [code, setCode] = useState<string | null>(null);
   const convex = useConvex();
   return (
     <div className="flex flex-col items-center justify-center h-full gap-4">
@@ -113,7 +113,7 @@ function AccessGateForm({ setHasValidCode }: { setHasValidCode: (hasValidCode: b
       >
         <input
           type="text"
-          value={code}
+          value={code || ''}
           onChange={(e) => setCode(e.target.value)}
           placeholder="Enter your invite code"
           className={classNames(

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -16,7 +16,8 @@ export const meta: MetaFunction = () => {
 
 export const loader = async (args: LoaderFunctionArgs) => {
   const url = new URL(args.request.url);
-  const code = url.searchParams.get('code');
+  // an empty string code is confusing, consider it no code
+  const code = url.searchParams.get('code') || null;
   const flexAuthMode = getFlexAuthModeInLoader();
   return json({ code, flexAuthMode });
 };

--- a/app/routes/api.convex.callback.ts
+++ b/app/routes/api.convex.callback.ts
@@ -2,7 +2,8 @@ import { json, type LoaderFunctionArgs } from '@vercel/remix';
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url);
-  const code = url.searchParams.get('code');
+  // an empty string code is confusing, consider it no code
+  const code = url.searchParams.get('code') || null;
   const CLIENT_ID = globalThis.process.env.CONVEX_OAUTH_CLIENT_ID;
   const CLIENT_SECRET = globalThis.process.env.CONVEX_OAUTH_CLIENT_SECRET;
   const PROVISION_HOST = globalThis.process.env.PROVISION_HOST || 'https://api.convex.dev';

--- a/app/routes/chat.$id.tsx
+++ b/app/routes/chat.$id.tsx
@@ -13,7 +13,8 @@ export const meta = IndexMeta;
 export async function loader(args: LoaderFunctionArgs) {
   const flexAuthMode = getFlexAuthModeInLoader();
   const url = new URL(args.request.url);
-  const code = url.searchParams.get('code');
+  // an empty string code is confusing, consider it no code
+  const code = url.searchParams.get('code') || null;
   return json({ id: args.params.id, flexAuthMode, code });
 }
 


### PR DESCRIPTION
Prevents the issue where the first time in a preview deployment there'd be a failed request to sessions:getSession with a code of `""`.