### PR TITLE
Only use relative paths in file actions

### DIFF
--- a/app/components/chat/Artifact.tsx
+++ b/app/components/chat/Artifact.tsx
@@ -8,9 +8,9 @@ import { workbenchStore } from '~/lib/stores/workbench';
 import { type PartId } from '~/lib/stores/artifacts';
 import { classNames } from '~/utils/classNames';
 import { cubicEasingFn } from '~/utils/easings';
-import { WORK_DIR } from '~/utils/constants';
 import { captureException } from '@sentry/remix';
-
+import type { RelativePath } from '~/lib/stores/files';
+import { getAbsolutePath } from '~/lib/stores/files';
 const highlighterOptions = {
   langs: ['shell'],
   themes: ['light-plus', 'dark-plus'],
@@ -135,12 +135,12 @@ const actionVariants = {
   visible: { opacity: 1, y: 0 },
 };
 
-function openArtifactInWorkbench(filePath: any) {
+function openArtifactInWorkbench(filePath: RelativePath) {
   if (workbenchStore.currentView.get() !== 'code') {
     workbenchStore.currentView.set('code');
   }
 
-  workbenchStore.setSelectedFile(`${WORK_DIR}/${filePath}`);
+  workbenchStore.setSelectedFile(getAbsolutePath(filePath));
 }
 
 const ActionList = memo(({ actions }: ActionListProps) => {

--- a/app/components/workbench/Workbench.client.tsx
+++ b/app/components/workbench/Workbench.client.tsx
@@ -102,7 +102,8 @@ export const Workbench = memo(({ chatStarted, isStreaming, terminalInitializatio
 
   const onFileSelect = useCallback((filePath: string | undefined) => {
     workbenchStore.followingStreamedCode.set(false);
-    workbenchStore.setSelectedFile(filePath);
+    const absPath = filePath ? getAbsolutePath(filePath) : undefined;
+    workbenchStore.setSelectedFile(absPath);
   }, []);
 
   const onFileSave = useCallback(() => {

--- a/app/lib/runtime/message-parser.ts
+++ b/app/lib/runtime/message-parser.ts
@@ -3,6 +3,7 @@ import type { BoltArtifactData } from '~/types/artifact';
 import { createScopedLogger } from '~/utils/logger';
 import { unreachable } from '~/utils/unreachable';
 import type { PartId } from '~/lib/stores/artifacts';
+import { getRelativePath } from '~/lib/stores/files';
 
 const ARTIFACT_TAG_OPEN = '<boltArtifact';
 const ARTIFACT_TAG_CLOSE = '</boltArtifact>';
@@ -321,7 +322,7 @@ export class StreamingMessageParser {
         logger.debug('File path not specified');
       }
 
-      (actionAttributes as FileAction).filePath = filePath;
+      (actionAttributes as FileAction).filePath = getRelativePath(filePath);
     } else {
       logger.warn(`Unknown action type '${actionType}'`);
     }

--- a/app/lib/stores/editor.ts
+++ b/app/lib/stores/editor.ts
@@ -57,7 +57,7 @@ export class EditorStore {
     );
   }
 
-  setSelectedFile(filePath: string | undefined) {
+  setSelectedFile(filePath: AbsolutePath | undefined) {
     this.selectedFile.set(filePath);
   }
 

--- a/app/lib/stores/files.ts
+++ b/app/lib/stores/files.ts
@@ -27,7 +27,7 @@ interface Folder {
 export type Dirent = File | Folder;
 
 // Relative to `WORK_DIR`
-type RelativePath = string & { __brand: 'RelativePath' };
+export type RelativePath = string & { __brand: 'RelativePath' };
 export type AbsolutePath = string & { __brand: 'AbsolutePath' };
 
 export const getAbsolutePath = (pathString: string): AbsolutePath => {

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -346,7 +346,9 @@ export class WorkbenchStore {
       // we find the first file and select it
       for (const [filePath, dirent] of Object.entries(files)) {
         if (dirent?.type === 'file') {
-          this.setSelectedFile(filePath);
+          // Note -- cast is safe since `FileMap` is a record of `AbsolutePath` -> `Dirent`,
+          // but `Object.entries` loses the type information.
+          this.setSelectedFile(filePath as AbsolutePath);
           break;
         }
       }
@@ -402,10 +404,9 @@ export class WorkbenchStore {
     this.#editorStore.updateScrollPosition(filePath, position);
   }
 
-  setSelectedFile(filePath: string | undefined) {
+  setSelectedFile(filePath: AbsolutePath | undefined) {
     this.setLastChangedFile();
-    const absPath = filePath ? getAbsolutePath(filePath) : undefined;
-    this.#editorStore.setSelectedFile(absPath);
+    this.#editorStore.setSelectedFile(filePath);
   }
 
   async saveFile(filePath: string) {
@@ -579,7 +580,7 @@ export class WorkbenchStore {
         const selectedView = workbenchStore.currentView.value;
         const followingStreamedCode = workbenchStore.followingStreamedCode.get();
         if (selectedView === 'code' && followingStreamedCode) {
-          this.setSelectedFile(fullPath);
+          this.setSelectedFile(fullPath as AbsolutePath);
         }
       }
 

--- a/app/types/actions.ts
+++ b/app/types/actions.ts
@@ -1,5 +1,5 @@
 import type { Change } from 'diff';
-
+import type { RelativePath } from '~/lib/stores/files';
 export type ActionType = 'file' | 'toolUse';
 
 interface BaseAction {
@@ -8,7 +8,7 @@ interface BaseAction {
 
 export interface FileAction extends BaseAction {
   type: 'file';
-  filePath: string;
+  filePath: RelativePath;
   isEdit?: boolean;
 }
 


### PR DESCRIPTION
I think occasionally we'd get an absolute path in there and we'd both display it, and then clicking on it would try and open `/$WORK_DIR/$WORK_DIR/path/to/whatever`