### PR TITLE
Skip a click during signin and don't intercept GitHub code

### DIFF
--- a/app/components/chat/Chat.tsx
+++ b/app/components/chat/Chat.tsx
@@ -148,8 +148,7 @@ export const Chat = memo(
     });
 
     useEffect(() => {
-      // an empty string code is confusing, consider it no code
-      const prompt = searchParams.get('prompt') || null;
+      const prompt = searchParams.get('prompt');
 
       if (!prompt) {
         return;

--- a/app/components/chat/FlexAuthWrapper.tsx
+++ b/app/components/chat/FlexAuthWrapper.tsx
@@ -12,14 +12,12 @@ import { sessionIdStore, setInitialConvexSessionId, setConvexSessionIdFromCode }
 import { useConvexSessionIdOrNullOrLoading } from '~/lib/stores/sessionId';
 import { classNames } from '~/utils/classNames';
 import { Loading } from '~/components/Loading';
+import type { loader } from '~/routes/_index';
 
 export function FlexAuthWrapper({ children }: { children: React.ReactNode }) {
   const sessionId = useConvexSessionIdOrNullOrLoading();
   const convex = useConvex();
-  const { code: codeFromLoader, flexAuthMode } = useLoaderData<{
-    code?: string;
-    flexAuthMode: 'InviteCode' | 'ConvexOAuth';
-  }>();
+  const { code: codeFromLoader, flexAuthMode } = useLoaderData<typeof loader>();
   const { isAuthenticated, isLoading: isConvexAuthLoading } = useConvexAuth();
   useEffect(() => {
     flexAuthModeStore.set(flexAuthMode);
@@ -187,7 +185,11 @@ function ConvexSignInForm() {
       <button
         className="px-4 py-2 rounded-lg border-1 border-bolt-elements-borderColor flex items-center gap-2 text-bolt-elements-button-primary disabled:opacity-50 disabled:cursor-not-allowed bg-bolt-elements-button-secondary-background hover:bg-bolt-elements-button-secondary-backgroundHover"
         onClick={() => {
-          loginWithRedirect();
+          loginWithRedirect({
+            authorizationParams: {
+              connection: 'github',
+            },
+          });
         }}
       >
         <img className="w-4 h-4" height="16" width="16" src="/icons/Convex.svg" alt="Convex" />

--- a/app/lib/stores/sessionId.ts
+++ b/app/lib/stores/sessionId.ts
@@ -43,7 +43,7 @@ export const sessionIdStore = atom<Id<'sessions'> | null | undefined>(undefined)
 export function setInitialConvexSessionId(
   convex: ConvexReactClient,
   args: {
-    codeFromLoader: string | undefined;
+    codeFromLoader: string | null;
     flexAuthMode: 'InviteCode' | 'ConvexOAuth';
   },
 ) {

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -16,8 +16,13 @@ export const meta: MetaFunction = () => {
 
 export const loader = async (args: LoaderFunctionArgs) => {
   const url = new URL(args.request.url);
-  // an empty string code is confusing, consider it no code
-  const code = url.searchParams.get('code') || null;
+  let code: string | null = url.searchParams.get('code');
+  const state = url.searchParams.get('state');
+  // If state is also set, this is probably the GitHub OAuth login flow finishing.
+  // The code is probably not for us.
+  if (state) {
+    code = null;
+  }
   const flexAuthMode = getFlexAuthModeInLoader();
   return json({ code, flexAuthMode });
 };

--- a/app/routes/api.convex.callback.ts
+++ b/app/routes/api.convex.callback.ts
@@ -2,8 +2,7 @@ import { json, type LoaderFunctionArgs } from '@vercel/remix';
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url);
-  // an empty string code is confusing, consider it no code
-  const code = url.searchParams.get('code') || null;
+  const code = url.searchParams.get('code');
   const CLIENT_ID = globalThis.process.env.CONVEX_OAUTH_CLIENT_ID;
   const CLIENT_SECRET = globalThis.process.env.CONVEX_OAUTH_CLIENT_SECRET;
   const PROVISION_HOST = globalThis.process.env.PROVISION_HOST || 'https://api.convex.dev';

--- a/app/routes/chat.$id.tsx
+++ b/app/routes/chat.$id.tsx
@@ -13,8 +13,7 @@ export const meta = IndexMeta;
 export async function loader(args: LoaderFunctionArgs) {
   const flexAuthMode = getFlexAuthModeInLoader();
   const url = new URL(args.request.url);
-  // an empty string code is confusing, consider it no code
-  const code = url.searchParams.get('code') || null;
+  const code = url.searchParams.get('code');
   return json({ id: args.params.id, flexAuthMode, code });
 }
 


### PR DESCRIPTION
We were intercepting the `?code=` from the GitHub login flow, now if there's a state param assume it's not the right one. A pre-existing code still gets passed through, so handing out https://chef.convex.dev?code=vip still works.