### PR TITLE
Try including more info on preview error message

### DIFF
--- a/app/components/chat/ChatAlert.tsx
+++ b/app/components/chat/ChatAlert.tsx
@@ -71,7 +71,7 @@ export default function ChatAlert({ alert, clearAlert, postMessage }: Props) {
                 <button
                   onClick={() =>
                     postMessage(
-                      `*Fix this ${isPreview ? 'preview' : 'terminal'} error* \n\`\`\`${isPreview ? 'js' : 'sh'}\n${content}\n\`\`\`\n`,
+                      `*Fix this ${isPreview ? 'preview' : 'terminal'} error* \n\`\`\`${isPreview ? 'js' : 'sh'}\n${description}\n${content}\n\`\`\`\n`,
                     )
                   }
                   className={classNames(


### PR DESCRIPTION
We should the `description`, but not the `content`, so it's possible that the description has some extra context that the `content` does not.

I think [this](https://github.com/get-convex/flex-diy/blob/d5385d0934893a96ad15e17864757c6762936e05/app/lib/webcontainer/index.ts#L47) is main entrypoint (it seems possible that errors have nice message but not nice stack).