### PR TITLE
Share fetch code between client/server -> big-brain

### DIFF
--- a/app/components/chat/Chat.tsx
+++ b/app/components/chat/Chat.tsx
@@ -40,6 +40,7 @@ const logger = createScopedLogger('Chat');
 const MAX_RETRIES = 3;
 
 const CHEF_TOO_BUSY_ERROR = 'Chef is too busy cooking right now. Please try again in a moment.';
+const VITE_PROVISION_HOST = import.meta.env.VITE_PROVISION_HOST || 'https://api.convex.dev';
 
 const processSampledMessages = createSampler(
   (options: {
@@ -217,11 +218,15 @@ export const Chat = memo(
           throw new Error('No token');
         }
 
-        const tokenUsage = await getTokenUsage(token, teamSlug);
-        const { tokensUsed, tokensQuota } = tokenUsage;
-        if (tokensUsed !== undefined && tokensQuota !== undefined) {
-          console.log(`Convex tokens used/quota: ${tokensUsed} / ${tokensQuota}`);
-          setOverQuota(tokensUsed > tokensQuota);
+        const tokenUsage = await getTokenUsage(VITE_PROVISION_HOST, token, teamSlug);
+        if (tokenUsage.status === 'error') {
+          console.error('Failed to check for token usage', tokenUsage.httpStatus, tokenUsage.httpBody);
+        } else {
+          const { tokensUsed, tokensQuota } = tokenUsage;
+          if (tokensUsed !== undefined && tokensQuota !== undefined) {
+            console.log(`Convex tokens used/quota: ${tokensUsed} / ${tokensQuota}`);
+            setOverQuota(tokensUsed > tokensQuota);
+          }
         }
       },
     });

--- a/app/lib/.server/chat.ts
+++ b/app/lib/.server/chat.ts
@@ -71,7 +71,9 @@ export async function chatAction({ request }: ActionFunctionArgs) {
     if (!userApiKey) {
       const resp = await checkTokenUsage(PROVISION_HOST, token, teamSlug, deploymentName);
       if (resp.status === 'error') {
-        return resp.response;
+        return new Response(JSON.stringify({ error: 'Failed to check for tokens' }), {
+          status: resp.httpStatus,
+        });
       }
       if (resp.tokensUsed >= resp.tokensQuota) {
         if (body.userApiKey?.preference === 'quotaExhausted') {


### PR DESCRIPTION
Since both are calling the same getQuota endpoint - share the
code so it's easier to not mess it up when changing it.