### PR TITLE
Log backend errors

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -6,9 +6,6 @@ import { hydrateRoot } from 'react-dom/client';
 Sentry.init({
   dsn: 'https://16615d9875b4630cfabeed5d376c4343@o1192621.ingest.us.sentry.io/4509097600811008',
   tracesSampleRate: 1,
-  // TODO do we need to add release and environment here?
-
-  enabled: process.env.NODE_ENV === 'production',
 
   integrations: [
     Sentry.feedbackIntegration({

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -2,6 +2,7 @@ import type { AppLoadContext, EntryContext } from '@vercel/remix';
 import { RemixServer } from '@remix-run/react';
 import { isbot } from 'isbot';
 import * as Sentry from '@sentry/remix';
+import { waitUntil } from '@vercel/functions';
 import type { renderToReadableStream as RenderToReadableStream } from 'react-dom/server';
 // @ts-ignore There just aren't types for it, long-standing issue
 import { renderToReadableStream as renderToReadableStreamSSR } from 'react-dom/server.browser';
@@ -10,9 +11,16 @@ const renderToReadableStream = renderToReadableStreamSSR as typeof RenderToReada
 import { Head } from './root';
 import { themeStore } from '~/lib/stores/theme';
 
-export const handleError = Sentry.wrapHandleErrorWithSentry((_error, {}) => {
-  // Custom handleError implementation
+Sentry.init({
+  dsn: 'https://16615d9875b4630cfabeed5d376c4343@o1192621.ingest.us.sentry.io/4509097600811008',
+  tracesSampleRate: 1,
 });
+
+export function handleError(error: Error, { request }: { request: Request }) {
+  Sentry.captureRemixServerException(error, 'remix.server', request);
+  console.log('this is the handleErr');
+  waitUntil(Sentry.flush());
+}
 
 export default async function handleRequest(
   request: Request,

--- a/app/routes/api.tom-testing-error.tsx
+++ b/app/routes/api.tom-testing-error.tsx
@@ -1,0 +1,14 @@
+import { json, type ActionFunctionArgs } from '@vercel/remix';
+
+export async function loader(args: ActionFunctionArgs) {
+  if (new URL(args.request.url).searchParams.get('throw')) {
+    anotherFunction();
+    return json({ foo: 'bar' });
+  }
+  return json({ foo: 'bar' });
+}
+
+function anotherFunction() {
+  console.log('about to throw an error...');
+  throw new Error('This is a test error');
+}


### PR DESCRIPTION
also adds a test endpoint `/api/tom-testing-error?throw=true` to make sure backend errors are working in various environments