### PR TITLE
Block fully authenticated on Auth0 auth propagating to Convex

### DIFF
--- a/app/components/chat/ChefAuthWrapper.tsx
+++ b/app/components/chat/ChefAuthWrapper.tsx
@@ -110,7 +110,7 @@ export const ChefAuthProvider = ({
   }, [sessionId, isAuthenticated, isConvexAuthLoading, sessionIdFromLocalStorage, setSessionIdFromLocalStorage]);
 
   const isLoading = sessionId === undefined || isConvexAuthLoading;
-  const isUnauthenticated = sessionId === null || !isAuthenticated;
+  const isUnauthenticated = sessionId === null || !isAuthenticated || isConvexAuthLoading;
   const state: ChefAuthState = isLoading
     ? { kind: 'loading' }
     : isUnauthenticated


### PR DESCRIPTION
I think a race can happen where the smaller pop up logs you in and sets your Auth0 state, the `useEffect` runs when it notices the change in local storage, and switched to "fullyLoggedIn" before the original tab's Auth0 state + `useConvexAuth` state has updated.

So anything coming from Auth0's `useAuth` hook might fail