### PR TITLE
Add extra prompting around storage

### DIFF
--- a/app/components/chat/SuggestionButtons.tsx
+++ b/app/components/chat/SuggestionButtons.tsx
@@ -27,7 +27,7 @@ export const SuggestionButtons = ({ chatStarted, onSuggestionClick, disabled }: 
     {
       title: 'Build a Splitwise clone',
       prompt:
-        'Build a group shared expenses app that has the following features:\n\n• Has users, groups, expenses, payments, and reimbursements\n• Represents members in a group via a table rather than an array\n• Users can create groups and invite other users to join\n• Group members can add expenses to a group, which get shared among all members in the group\n• Shows a list of members in the group and a list of expenses along with who paid them\n• Show how much every member has been paid and reimbursed\n• Each member should be able to record a payment to another member, which adds to how much they have paid and adds to how much the recipient has been reimbursed\n• Members should record payments so that every member in the group has the same net balance',
+        'Build a group shared expenses app that has the following features:\n\n• Has users, groups, expenses, payments, and reimbursements\n• Represents members in a group via a table rather than an array\n• Users can create groups and invite other users to join\n• Group members can add expenses to a group, which get shared among all members in the group\n• Shows a list of members in the group and a list of expenses along with who paid them\n• Shows how much every member has been paid and reimbursed\n• Each member should be able to record a payment to another member, which adds to how much they have paid and adds to how much the recipient has been reimbursed\n• Members should record payments so that every member in the group has the same net balance',
     },
   ];
 

--- a/app/lib/common/prompts/convexGuidelines.ts
+++ b/app/lib/common/prompts/convexGuidelines.ts
@@ -509,8 +509,8 @@ export const exampleQuery = query({
 # Examples
 ## Example of using Convex storage within a chat app
 
-This example creates a mutation to generate a short-lived upload URL and a mutation to save an image message to the database. Then, it uses the generated upload URL to upload an image to Convex storage on the client side.
-Then, it gets the storage id from the response of the upload and saves it to the database with the \`sendImage\` mutation. It uses the \`list\` query to get the messages from the database and display them in the UI. The
+This example creates a mutation to generate a short-lived upload URL and a mutation to save an image message to the database. This mutation is called from the client, which uses the generated upload URL to upload an image to Convex storage. Then,
+it gets the storage id from the response of the upload and saves it to the database with the \`sendImage\` mutation. On the frontend, it uses the \`list\` query to get the messages from the database and display them in the UI. In this query, the
 backend grabs the url from the storage system table and returns it to the client which shows the images in the UI. You should use this pattern for any file upload. To keep track of files, you should save the storage id in the database.
 
 Path: \`convex/messages.ts\`


### PR DESCRIPTION
The LLM liked to store the file storage url in the database, so I prompted it specifically not to do this, which led to better usage of Convex storage. I tested with our built-in prompts of slack and instagram clones.