### PR TITLE
Annotate errors with whether the user provided their own API key

### DIFF
--- a/app/components/chat/Chat.tsx
+++ b/app/components/chat/Chat.tsx
@@ -217,6 +217,7 @@ export const Chat = memo(
           level: 'error',
           extra: {
             error: e,
+            userHasOwnApiKey: !!apiKey,
           },
         });
         logger.error('Request failed\n\n', e, error);


### PR DESCRIPTION
Since folks can configure an API key to happen only when they're over the quota, this is an overestimate, but should be an ok way to filter out errors from using our credentials vs. user provided ones.