### PR TITLE
Handle more in progress tool calls

### DIFF
--- a/app/lib/stores/startup/useInitialMessages.ts
+++ b/app/lib/stores/startup/useInitialMessages.ts
@@ -60,15 +60,19 @@ export function useInitialMessages(chatId: string):
           }
 
           const updatedParts = message.parts.map((part) => {
-            if (part.type === 'tool-invocation' && part.toolInvocation.state === 'partial-call') {
-              return {
-                ...part,
-                toolInvocation: {
-                  ...part.toolInvocation,
-                  state: 'result' as const,
-                  result: 'Error: Tool call was interrupted',
-                },
-              };
+            if (part.type === 'tool-invocation') {
+              // We could potentially handle these better by making the action runner
+              // handle the interrupted calls, but treat these as failed states for now.
+              if (part.toolInvocation.state === 'partial-call' || part.toolInvocation.state === 'call') {
+                return {
+                  ...part,
+                  toolInvocation: {
+                    ...part.toolInvocation,
+                    state: 'result' as const,
+                    result: 'Error: Tool call was interrupted',
+                  },
+                };
+              }
             }
             return part;
           });


### PR DESCRIPTION
If the agent has started a call but the action runner never got to it, we crash on loading the initial messages with [this error](https://sdk.vercel.ai/docs/troubleshooting/tool-invocation-missing-result).

So broadening the existing check to treat these as failed calls.