### PR TITLE
Tweak error handling for user API keys

### DIFF
--- a/app/lib/.server/llm/convex-agent.ts
+++ b/app/lib/.server/llm/convex-agent.ts
@@ -152,6 +152,9 @@ export async function convexAgent(
       const userKeyApiFetch = () => {
         return async (input: RequestInfo | URL, init?: RequestInit) => {
           const result = await fetch(input, init);
+          if (result.status === 401) {
+            throw new Error(JSON.stringify({ error: 'Invalid API key' }));
+          }
           if (result.status === 413) {
             const text = await result.text();
             throw new Error(
@@ -165,6 +168,14 @@ export async function convexAgent(
           if (result.status === 529) {
             const text = await result.text();
             throw new Error(JSON.stringify({ error: "Anthropic's API is temporarily overloaded", details: text }));
+          }
+          if (!result.ok) {
+            const text = await result.text();
+            throw new Error(
+              JSON.stringify({
+                error: `Anthropic returned an error (${result.status} ${result.statusText}) when using your provided API key: ${text}`,
+              }),
+            );
           }
           return result;
         };


### PR DESCRIPTION
We have tagging on the client side errors for whether the user has provided their own API key or not, but added a specific one to catch the `x-api-key` header one (it's a 401) + a catch-all that makes it clear it's a user provided API key.