### PR TITLE
Undo permanent three dots at bottom of chat

### DIFF
--- a/app/components/chat/Messages.client.tsx
+++ b/app/components/chat/Messages.client.tsx
@@ -69,7 +69,7 @@ export const Messages = forwardRef<HTMLDivElement, MessagesProps>(
               );
             })
           : null}
-        {(isStreaming || true) && (
+        {isStreaming && (
           <div className="w-full flex justify-center text-bolt-elements-textSecondary mt-4">
             <SpinnerThreeDots className="size-9" />
           </div>


### PR DESCRIPTION
This was modified [here](https://github.com/get-convex/flex-diy/pull/320/files#diff-f889df414e296b7af31b6837c809c59c72d84f4a25f9d13a147684b12c6ffbfa) and I'm guessing was unintentional (it makes the three dots loading UI show unconditionally)