### PR TITLE
Fix the OpenGraph image URL for chef.show links

### DIFF
--- a/app/routes/share.$shareCode.tsx
+++ b/app/routes/share.$shareCode.tsx
@@ -25,7 +25,7 @@ export const meta: MetaFunction = () => {
     },
     {
       property: 'og:image',
-      content: '/social_preview_share.jpg',
+      content: 'https://chef.convex.dev/social_preview_share.jpg',
     },
   ];
 };


### PR DESCRIPTION
I have a theory that some platforms might be trying to resolve og:image relative to the original URL (it's what https://orcascan.com/tools/open-graph-validator?url=https%3A%2F%2Fchef.show%2FCHEFSHOW is trying to do). Let’s try using an absolute URL instead for share codes.