### PR TITLE
Fix racing vite on reload

### DIFF
--- a/app/components/workbench/terminal/TerminalTabs.tsx
+++ b/app/components/workbench/terminal/TerminalTabs.tsx
@@ -132,7 +132,7 @@ export const TerminalTabs = memo((terminalInitializationOptions?: TerminalInitia
               }}
               onTerminalReady={(terminal) => {
                 if (index === VITE_TAB_INDEX) {
-                  workbenchStore.attachBoltTerminal(terminal, terminalInitializationOptions?.isReload ?? false);
+                  workbenchStore.attachBoltTerminal(terminal);
                 } else if (index === CONVEX_DEPLOY_TAB_INDEX) {
                   workbenchStore.attachDeployTerminal(terminal, {
                     ...terminalInitializationOptions,

--- a/app/lib/stores/terminal.ts
+++ b/app/lib/stores/terminal.ts
@@ -37,13 +37,13 @@ export class TerminalStore {
     this.showTerminal.set(value !== undefined ? value : !this.showTerminal.get());
   }
 
-  async attachBoltTerminal(terminal: ITerminal, isReload: boolean) {
+  async attachBoltTerminal(terminal: ITerminal) {
     try {
       const wc = await this.#webcontainer;
       await this.#boltTerminal.init(wc, terminal);
-      if (isReload) {
-        await this.#boltTerminal.executeCommand('npx vite --open');
-      }
+      // Note -- do not start the dev server here, since it will be handled by
+      // `attachDeployTerminal` and to avoid conflicts with `npx convex dev`
+      // triggering this server to restart
     } catch (error: any) {
       console.error('Failed to initialize bolt terminal:', error);
       terminal.write(coloredText.red('Failed to spawn dev server shell\n\n') + error.message);
@@ -65,12 +65,11 @@ export class TerminalStore {
         toast.error('Failed to deploy Convex functions. Check the terminal for more details.');
         workbenchStore.currentView.set('code');
         activeTerminalTabStore.set(CONVEX_DEPLOY_TAB_INDEX);
-        return;
+      } else {
+        isConvexDeployTerminalVisibleStore.set(false);
+        activeTerminalTabStore.set(VITE_TAB_INDEX);
+        toast.success('Convex functions deployed successfully');
       }
-
-      isConvexDeployTerminalVisibleStore.set(false);
-      activeTerminalTabStore.set(VITE_TAB_INDEX);
-      toast.success('Convex functions deployed successfully');
     }
 
     if (!workbenchStore.isDefaultPreviewRunning()) {

--- a/app/lib/stores/workbench.client.ts
+++ b/app/lib/stores/workbench.client.ts
@@ -232,8 +232,8 @@ export class WorkbenchStore {
   attachTerminal(terminal: ITerminal) {
     this.#terminalStore.attachTerminal(terminal);
   }
-  attachBoltTerminal(terminal: ITerminal, isReload: boolean) {
-    this.#terminalStore.attachBoltTerminal(terminal, isReload);
+  attachBoltTerminal(terminal: ITerminal) {
+    this.#terminalStore.attachBoltTerminal(terminal);
   }
   attachDeployTerminal(terminal: ITerminal, options?: TerminalInitializationOptions) {
     this.#terminalStore.attachDeployTerminal(terminal, options);


### PR DESCRIPTION
I believe we always attach both terminals. If we're reloading, and have convex code to push, we will run `npx convex dev --once`, then run `npx vite --open` when attaching the deploy terminal. And then we'll run `npx vite --open` when attaching the bolt terminal.

The bolt terminal's `npx vite --open` gets interrupted by the `npx convex dev --once` modifying `.env.local` and shows a kind of ugly error.

This proposed change is to just handle the `npx vite --open` when attaching the deploy terminal to avoid the race with the `npx convex dev --once`. The `npx vite --open` will still always run on startup, but it's just guaranteed to run after we've done `npx convex dev --once`. It means a delay in getting automatically dropped in your preview (you have to wait for the `npx convex dev --once`), but a lower chance that something is slightly broken (e.g. no errors about VITE_CONVEX_URL not being set)