### PR TITLE
fix link styling

### DIFF
--- a/app/components/chat/Chat.tsx
+++ b/app/components/chat/Chat.tsx
@@ -358,7 +358,10 @@ export const Chat = memo(
           message = (
             <>
               {message}
-              <a href="https://chef.convex.dev/settings">here</a>.
+              <a href="https://chef.convex.dev/settings" className="text-content-link hover:underline">
+                here
+              </a>
+              .
             </>
           );
         } else {


### PR DESCRIPTION
The link wasn't highlighted/underlined before.

![Screenshot 2025-04-16 at 4 00 48 PM](https://github.com/user-attachments/assets/97103c95-1490-429a-9a83-adfcf0f3a6e7)
