### PR TITLE
Fix visual glitch with the bottom of in-chat terminals

### DIFF
--- a/app/components/chat/ToolCall.tsx
+++ b/app/components/chat/ToolCall.tsx
@@ -151,12 +151,11 @@ function DeployTool({ artifact, invocation }: { artifact: ArtifactState; invocat
     throw new Error('Terminal can only be used for the deploy tool');
   }
 
-  if (invocation.state === 'call') {
+  if (invocation.state === 'call' || invocation.state === 'result') {
     return <Terminal artifact={artifact} invocation={invocation} />;
   }
-  if (invocation.state === 'result') {
-    return <Terminal artifact={artifact} invocation={invocation} />;
-  }
+
+  return null;
 }
 
 const Terminal = memo(
@@ -237,14 +236,11 @@ function NpmInstallTool({ artifact, invocation }: { artifact: ArtifactState; inv
     throw new Error('Terminal can only be used for the npmInstall tool');
   }
 
-  if (invocation.state === 'call') {
+  if (invocation.state === 'call' || (invocation.state === 'result' && invocation.result.startsWith('Error:'))) {
     return <Terminal artifact={artifact} invocation={invocation} />;
   }
-  if (invocation.state === 'result') {
-    if (invocation.result.startsWith('Error:')) {
-      return <Terminal artifact={artifact} invocation={invocation} />;
-    }
-  }
+
+  return null;
 }
 
 function parseToolInvocation(


### PR DESCRIPTION
- Fixes a visual bug where the bottom part of in-chat terminals would be of the correct color
- Reduces code duplication
- Add missing `null` return values