### PR TITLE
Fix useStoreMessageHistory dependencies

### DIFF
--- a/app/lib/stores/startup/index.ts
+++ b/app/lib/stores/startup/index.ts
@@ -5,12 +5,13 @@ import { useProjectInitializer } from './useProjectInitializer';
 import { useTeamsInitializer } from './useTeamsInitializer';
 import { useExistingChatContainerSetup, useNewChatContainerSetup } from './useContainerSetup';
 import { useBackupSyncState } from './history';
+
 export function useConvexChatHomepage(chatId: string) {
   useTeamsInitializer();
   useProjectInitializer(chatId);
   const initializeChat = useHomepageInitializeChat(chatId);
   useBackupSyncState(chatId, []);
-  const storeMessageHistory = useStoreMessageHistory(chatId);
+  const storeMessageHistory = useStoreMessageHistory();
   useNewChatContainerSetup();
 
   return {
@@ -25,7 +26,7 @@ export function useConvexChatExisting(chatId: string) {
   const initializeChat = useExistingInitializeChat(chatId);
   const initialMessages = useInitialMessages(chatId);
   useBackupSyncState(chatId, initialMessages?.deserialized);
-  const storeMessageHistory = useStoreMessageHistory(chatId);
+  const storeMessageHistory = useStoreMessageHistory();
   useExistingChatContainerSetup(initialMessages?.loadedChatId);
   return {
     initialMessages: !initialMessages ? initialMessages : initialMessages?.deserialized,


### PR DESCRIPTION
The `useCallback` dependencies of `useStoreMessageHistory` don’t seem to be used. This also means that the parameter of `useStoreMessageHistory` can be removed. This change looks safe to me, but I’d appreciate a confirmation since it looks weird that we have an unused parameter there.