### PR TITLE
Fix calls to `debounce` in React components

### DIFF
--- a/app/components/chat/Chat.tsx
+++ b/app/components/chat/Chat.tsx
@@ -2,7 +2,7 @@ import { useStore } from '@nanostores/react';
 import type { Message } from 'ai';
 import { useChat } from '@ai-sdk/react';
 import { useAnimate } from 'framer-motion';
-import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { memo, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useMessageParser, type PartCache } from '~/lib/hooks/useMessageParser';
 import { useSnapScroll } from '~/lib/hooks/useSnapScroll';
 import { description } from '~/lib/stores/description';

--- a/app/lib/hooks/useSearchFilter.ts
+++ b/app/lib/hooks/useSearchFilter.ts
@@ -1,5 +1,4 @@
 import { useState, useMemo, useCallback } from 'react';
-import { debounce } from '~/utils/debounce';
 import type { ChatHistoryItem } from '~/types/ChatHistoryItem';
 import { useDebounce } from '@uidotdev/usehooks';
 


### PR DESCRIPTION
`debounce` from `app/utils` is implemented using a mutable `timeout` variable. While the usage in the codebase isn’t incorrect since it is wrapped in `useCallback` calls that make `debounce` called only once, it makes it confusing for ESLint to track `useCallback` dependencies.