### PR TITLE
Hoist `dashboardHost` in convex.connect

### DIFF
--- a/app/routes/convex.connect.tsx
+++ b/app/routes/convex.connect.tsx
@@ -7,10 +7,10 @@ export const meta: MetaFunction = () => {
   return [{ title: 'Loading | Chef' }];
 };
 
+const dashboardHost = import.meta.env.VITE_DASHBOARD_HOST || 'https://dashboard.convex.dev';
+
 export default function ConvexConnect() {
   const [searchParams] = useSearchParams();
-
-  const dashboardHost = import.meta.env.VITE_DASHBOARD_HOST || 'https://dashboard.convex.dev';
 
   useEffect(() => {
     const params = new URLSearchParams(searchParams);


### PR DESCRIPTION
This avoids having to add a static dependency in `useEffect`