### PR TITLE
Add the missing `launchdarkly` useEffect dep

### DIFF
--- a/app/components/UserProvider.tsx
+++ b/app/components/UserProvider.tsx
@@ -75,7 +75,7 @@ function UserProviderInner({ children }: { children: React.ReactNode }) {
       }
     }
     void updateProfile();
-  }, [user, convex]);
+  }, [launchdarkly, user, convex]);
 
   return children;
 }


### PR DESCRIPTION
Making clear that launchdarkly won’t cause useEffect dependency issues (and it shouldn’t change the behavior since I’m assuming `useLDClient` always returns the same object)