### PR TITLE
Fix useEffect in PortDropdown

### DIFF
--- a/app/components/workbench/PortDropdown.tsx
+++ b/app/components/workbench/PortDropdown.tsx
@@ -35,16 +35,15 @@ export const PortDropdown = memo(function PortDropdown({
       }
     };
 
-    if (isDropdownOpen) {
-      window.addEventListener('mousedown', handleClickOutside);
-    } else {
-      window.removeEventListener('mousedown', handleClickOutside);
+    if (!isDropdownOpen) {
+      return undefined;
     }
 
+    window.addEventListener('mousedown', handleClickOutside);
     return () => {
       window.removeEventListener('mousedown', handleClickOutside);
     };
-  }, [isDropdownOpen]);
+  }, [isDropdownOpen, setIsDropdownOpen]);
 
   return (
     <div className="z-port-dropdown relative" ref={dropdownRef}>


### PR DESCRIPTION
- Calling removeEventListener with a function that was just created is useless so we can just remove it
- Adding setIsDropdownOpen as a dependency to useEffect. This shouldn’t change in practice but it doesn’t hurt to be safe
