### PR TITLE
Fix layout on small screens

### DIFF
--- a/app/components/workbench/Workbench.client.tsx
+++ b/app/components/workbench/Workbench.client.tsx
@@ -182,7 +182,7 @@ export const Workbench = memo(function Workbench({
               {
                 'w-full': isSmallViewport,
                 'left-0': showWorkbench && isSmallViewport,
-                'left-[var(--workbench-left)]': showWorkbench,
+                'left-[var(--workbench-left)]': showWorkbench && !isSmallViewport,
                 'left-[100%]': !showWorkbench,
               },
             )}


### PR DESCRIPTION
This was caused by a change in the priority between classes when switching from UnoCSS to Tailwind.