### PR TITLE
Don't suggest rewind to user messages

### DIFF
--- a/app/components/chat/Messages.client.tsx
+++ b/app/components/chat/Messages.client.tsx
@@ -126,6 +126,7 @@ export const Messages = forwardRef<HTMLDivElement, MessagesProps>(function Messa
                 {isUserMessage ? <UserMessage content={content} /> : <AssistantMessage message={message} />}
                 {rewindButton &&
                   earliestRewindableMessageRank !== undefined &&
+                  !isUserMessage &&
                   index >= earliestRewindableMessageRank &&
                   index !== messages.length - 1 && (
                     <Button


### PR DESCRIPTION
This seems to fix a bug (rewinding to the first user message sometimes failed) but also prevents other rewinds to user messages because I think this is a confusing operation, it restores to a state that shows the user message but doesnt' reactivate the agent.