### PR TITLE
Add some retries on checking auth

### DIFF
--- a/app/components/chat/ChefAuthWrapper.tsx
+++ b/app/components/chat/ChefAuthWrapper.tsx
@@ -74,12 +74,12 @@ export const ChefAuthProvider = ({
 
     if (sessionId === undefined && isUnauthenticated) {
       setSessionId(null);
-      return;
+      return undefined;
     }
 
     if (sessionId !== null && isUnauthenticated) {
       setSessionId(null);
-      return;
+      return undefined;
     }
     let verifySessionTimeout: ReturnType<typeof setTimeout> | null = null;
 


### PR DESCRIPTION
My rough understanding here is that the auth0 provider does not actually react to another tab going through the auth0 flow, but calling `getAccessTokenSilently` tends to get stuff unstuck. Adding in some retries with a timeout to see if that helps anything.