### PR TITLE
Update chefshot to read messages from the db instead of from the dom

### DIFF
--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -336,7 +336,7 @@ export const updateStorageState = internalMutation({
       if (messageHistoryStorageId !== null) {
         // Should this error?
         console.warn(
-          `Received duplicate update for message hitsory, message ${lastMessageRank} part ${partIndex}, ignoring`,
+          `Received duplicate update for message history, message ${lastMessageRank} part ${partIndex}, ignoring`,
         );
         return;
       }


### PR DESCRIPTION
We can load the messages given the chat ID + session ID, which seems better than sticking the entire message history in the dom.

AFAICT, the `beforeunload` handler is functioning correctly, but when I try `page.close({ runBeforeUnload: true })`, it still closes the page too early before any chat history has been saved, so I currently have a kinda long timeout in there instead.