### PR TITLE
Record annotations with the chat's initial ID instead of the less unique urlId

### DIFF
--- a/app/components/chat/Chat.tsx
+++ b/app/components/chat/Chat.tsx
@@ -23,7 +23,7 @@ import { toast } from 'sonner';
 import type { PartId } from '~/lib/stores/artifacts';
 import { captureMessage } from '@sentry/remix';
 import type { ActionStatus } from '~/lib/runtime/action-runner';
-import { chatIdStore } from '~/lib/stores/chatId';
+import { chatIdStore, initialIdStore } from '~/lib/stores/chatId';
 import type { ModelProvider } from '~/lib/.server/llm/convex-agent';
 import { useConvex, useQuery } from 'convex/react';
 import type { ConvexReactClient } from 'convex/react';
@@ -226,7 +226,7 @@ export const Chat = memo(
       api: '/api/chat',
       sendExtraMessageFields: true,
       experimental_prepareRequestBody: ({ messages }) => {
-        const chatId = chatIdStore.get();
+        const chatInitialId = initialIdStore.get();
         const deploymentName = convexProjectStore.get()?.deploymentName;
         const teamSlug = selectedTeamSlugStore.get();
         const token = getConvexAuthToken(convex);
@@ -252,7 +252,7 @@ export const Chat = memo(
         return {
           messages: chatContextManager.current.prepareContext(messages),
           firstUserMessage: messages.filter((message) => message.role == 'user').length == 1,
-          chatId,
+          chatInitialId,
           token,
           teamSlug,
           deploymentName,

--- a/app/lib/.server/chat.ts
+++ b/app/lib/.server/chat.ts
@@ -53,7 +53,7 @@ export async function chatAction({ request }: ActionFunctionArgs) {
   const body = (await request.json()) as {
     messages: Messages;
     firstUserMessage: boolean;
-    chatId: string;
+    chatInitialId: string;
     token: string;
     teamSlug: string;
     deploymentName: string | undefined;
@@ -62,7 +62,7 @@ export async function chatAction({ request }: ActionFunctionArgs) {
       | { preference: 'always' | 'quotaExhausted'; value?: string; openai?: string; xai?: string; google?: string }
       | undefined;
   };
-  const { messages, firstUserMessage, chatId, deploymentName, token, teamSlug } = body;
+  const { messages, firstUserMessage, chatInitialId, deploymentName, token, teamSlug } = body;
 
   let useUserApiKey = false;
 
@@ -133,7 +133,7 @@ export async function chatAction({ request }: ActionFunctionArgs) {
     const totalMessageContent = messages.reduce((acc, message) => acc + message.content, '');
     logger.debug(`Total message length: ${totalMessageContent.split(' ').length}, words`);
     const dataStream = await convexAgent(
-      chatId,
+      chatInitialId,
       env,
       firstUserMessage,
       messages,

--- a/app/lib/.server/llm/convex-agent.ts
+++ b/app/lib/.server/llm/convex-agent.ts
@@ -49,7 +49,7 @@ export type ModelProvider = 'Anthropic' | 'Bedrock' | 'OpenAI' | 'XAI' | 'Google
 const ALLOWED_AWS_REGIONS = ['us-east-1', 'us-east-2', 'us-west-2'];
 
 export async function convexAgent(
-  chatId: string,
+  chatInitialId: string,
   env: Record<string, string | undefined>,
   firstUserMessage: boolean,
   messages: Messages,
@@ -284,7 +284,7 @@ export async function convexAgent(
         ],
         tools,
         onFinish: (result) => {
-          onFinishHandler(dataStream, messages, result, tracer, chatId, recordUsageCb);
+          onFinishHandler(dataStream, messages, result, tracer, chatInitialId, recordUsageCb);
         },
         onError({ error }) {
           console.error(error);
@@ -294,7 +294,7 @@ export async function convexAgent(
           isEnabled: true,
           metadata: {
             firstUserMessage,
-            chatId,
+            chatInitialId,
             provider: modelProvider,
           },
         },
@@ -384,7 +384,7 @@ async function onFinishHandler(
   messages: Messages,
   result: Omit<StepResult<any>, 'stepType' | 'isContinued'>,
   tracer: Tracer | null,
-  chatId: string,
+  chatInitialId: string,
   recordUsageCb: (
     lastMessage: Message | undefined,
     finalGeneration: { usage: LanguageModelUsage; providerMetadata?: ProviderMetadata },
@@ -403,7 +403,7 @@ async function onFinishHandler(
   });
   if (tracer) {
     const span = tracer.startSpan('on-finish-handler');
-    span.setAttribute('chatId', chatId);
+    span.setAttribute('chatInitialId', chatInitialId);
     span.setAttribute('finishReason', result.finishReason);
     span.setAttribute('usage.completionTokens', usage.completionTokens);
     span.setAttribute('usage.promptTokens', usage.promptTokens);

--- a/app/lib/stores/chatId.ts
+++ b/app/lib/stores/chatId.ts
@@ -39,6 +39,18 @@ export function setKnownInitialId(initialId: string) {
   knownInitialId.set(initialId);
 }
 
+// This is useful in places where we want a unique ID (e.g. logs) instead of the
+// more human-friendly `urlId`, which is only unique within the current session.
+export const initialIdStore = computed([pageLoadChatId, knownInitialId], (pageLoadChatId, knownInitialId) => {
+  if (knownInitialId !== undefined) {
+    return knownInitialId;
+  }
+  if (pageLoadChatId === undefined) {
+    throw new Error('initialIdStore used before pageLoadChatId was set');
+  }
+  return pageLoadChatId;
+});
+
 /*
  * We may not know a chat's `urlId` until its first message.
  */

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -70,7 +70,8 @@ export default defineSchema({
   })
     .index("byCreatorAndId", ["creatorId", "initialId"])
     .index("byCreatorAndUrlId", ["creatorId", "urlId"])
-    .index("bySnapshotId", ["snapshotId"]),
+    .index("bySnapshotId", ["snapshotId"])
+    .index("byInitialId", ["initialId"]),
 
   convexProjectCredentials: defineTable({
     projectSlug: v.string(),


### PR DESCRIPTION
The initial ID is a UUID, so we should be able to reliably look up more information about the chat in our Chef backend. The URL ID, which we were preferring before, can be something like `chat-app`, which is only unique within a session.

Am trying to avoid adding session IDs in our axiom logging since they're somewhat security sensitive.
