### PR TITLE
Don't require a package-lock.json file

### DIFF
--- a/test-kitchen/chefTask.ts
+++ b/test-kitchen/chefTask.ts
@@ -255,16 +255,10 @@ const copyFiles = wrapTraced(async function copyFiles(repoDir: string) {
   if (!stdout) {
     throw new Error('No output from git ls-files');
   }
-  const unignoredFiles = stdout
+  const templateFiles = stdout
     .trim()
     .split('\n')
     .filter((file) => file.length > 0);
-  const packageLockFile = 'package-lock.json';
-  if (!existsSync(path.join(TEMPLATE_DIR, packageLockFile))) {
-    throw new Error('package-lock.json not found');
-  }
-  const templateFiles = [...unignoredFiles, packageLockFile];
-
   for (const file of templateFiles) {
     const sourcePath = path.join(TEMPLATE_DIR, file);
     const targetPath = path.join(repoDir, file);


### PR DESCRIPTION
This is failing in CI since we don't have one: https://www.braintrust.dev/app/Convex/p/chef/experiments/main-1745436218?c=main-1745436218-f820caa4&r=4ffef204-8ca4-4ce8-bb80-dd2dc3b910dd&s=f262bde1-3f96-4183-9f47-066c0a54f8af