### PR TITLE
Move around VITE_PROVISION_HOST to avoid pulling client-only code into the server bundle

### DIFF
--- a/app/components/ChefSignInPage.tsx
+++ b/app/components/ChefSignInPage.tsx
@@ -10,7 +10,7 @@ import { useConvex, useConvexAuth } from 'convex/react';
 import { fetchOptIns } from '~/lib/convexOptins';
 import { Button } from '@ui/Button';
 import { Spinner } from '@ui/Spinner';
-
+import { VITE_PROVISION_HOST } from '~/lib/convexProvisionHost';
 export const ChefSignInPage = () => {
   const chefAuth = useChefAuthContext();
 
@@ -56,8 +56,6 @@ function ConvexSignInForm() {
     </div>
   );
 }
-
-const VITE_PROVISION_HOST = import.meta.env.VITE_PROVISION_HOST || 'https://api.convex.dev';
 
 type OptInToAccept = {
   optIn: {

--- a/app/components/chat/Chat.tsx
+++ b/app/components/chat/Chat.tsx
@@ -36,12 +36,11 @@ import { ExternalLinkIcon } from '@radix-ui/react-icons';
 import { useConvexSessionIdOrNullOrLoading } from '~/lib/stores/sessionId';
 import type { Doc, Id } from 'convex/_generated/dataModel';
 import { useFlags } from 'launchdarkly-react-client-sdk';
+import { VITE_PROVISION_HOST } from '~/lib/convexProvisionHost';
 
 const logger = createScopedLogger('Chat');
 
 const MAX_RETRIES = 4;
-
-export const VITE_PROVISION_HOST = import.meta.env.VITE_PROVISION_HOST || 'https://api.convex.dev';
 
 const processSampledMessages = createSampler(
   (options: {

--- a/app/components/settings/UsageCard.tsx
+++ b/app/components/settings/UsageCard.tsx
@@ -3,7 +3,7 @@ import { useConvex } from 'convex/react';
 import { useEffect, useState } from 'react';
 import { getStoredTeamSlug } from '~/lib/stores/convexTeams';
 import { convexTeamsStore } from '~/lib/stores/convexTeams';
-import { VITE_PROVISION_HOST } from '~/components/chat/Chat';
+import { VITE_PROVISION_HOST } from '~/lib/convexProvisionHost';
 import { getConvexAuthToken } from '~/lib/stores/sessionId';
 import { getTokenUsage, renderTokenCount } from '~/lib/convexUsage';
 import { TeamSelector } from '~/components/convex/TeamSelector';

--- a/app/lib/convexOptins.ts
+++ b/app/lib/convexOptins.ts
@@ -1,7 +1,6 @@
 import type { ConvexReactClient } from 'convex/react';
 import { getConvexAuthToken } from './stores/sessionId';
-
-const VITE_PROVISION_HOST = import.meta.env.VITE_PROVISION_HOST || 'https://api.convex.dev';
+import { VITE_PROVISION_HOST } from './convexProvisionHost';
 
 type OptInToAccept = {
   optIn: {

--- a/app/lib/convexProfile.ts
+++ b/app/lib/convexProfile.ts
@@ -1,4 +1,4 @@
-const VITE_PROVISION_HOST = import.meta.env.VITE_PROVISION_HOST || 'https://api.convex.dev';
+import { VITE_PROVISION_HOST } from './convexProvisionHost';
 
 interface ConvexProfile {
   name: string;

--- a/app/lib/convexProvisionHost.ts
+++ b/app/lib/convexProvisionHost.ts
@@ -1,0 +1,1 @@
+export const VITE_PROVISION_HOST = import.meta.env.VITE_PROVISION_HOST || 'https://api.convex.dev';

--- a/app/lib/stores/startup/useTeamsInitializer.ts
+++ b/app/lib/stores/startup/useTeamsInitializer.ts
@@ -5,8 +5,7 @@ import { getStoredTeamSlug, setSelectedTeamSlug } from '~/lib/stores/convexTeams
 import { toast } from 'sonner';
 import type { ConvexReactClient } from 'convex/react';
 import { useConvex } from 'convex/react';
-
-const VITE_PROVISION_HOST = import.meta.env.VITE_PROVISION_HOST || 'https://api.convex.dev';
+import { VITE_PROVISION_HOST } from '~/lib/convexProvisionHost';
 
 export function useTeamsInitializer() {
   const convex = useConvex();


### PR DESCRIPTION
`UsageCard` is server rendered, which imported `Chat`, which has some client-only imports (and should maybe be renamed to `Chat.client` now but literally just for `VITE_PROVISION_HOST`, so I moved the latter into its own file