### PR TITLE
Lock more auth files

### DIFF
--- a/chef-agent/constants.ts
+++ b/chef-agent/constants.ts
@@ -22,4 +22,4 @@ export const WORK_DIR = `/home/${WORK_DIR_NAME}`;
 export const PREWARM_PATHS = [`${WORK_DIR}/package.json`, `${WORK_DIR}/convex/schema.ts`, `${WORK_DIR}/src/App.tsx`];
 
 // A list of files that we block the LLM from modifying
-export const EXCLUDED_FILE_PATHS = ['convex/auth.ts', 'src/main.tsx'];
+export const EXCLUDED_FILE_PATHS = ['convex/auth.ts', 'src/main.tsx', 'src/SignInForm.tsx', 'src/SignOutButton.tsx'];

--- a/chef-agent/prompts/solutionConstraints.ts
+++ b/chef-agent/prompts/solutionConstraints.ts
@@ -151,8 +151,8 @@ function templateInfo() {
       This code configures Convex Auth to use just a username/password login method. Do NOT modify this
       file. If the user asks to support other login methods, tell them that this isn't currently possible
       within Chef. They can download the code and do it themselves.
-      IMPORTANT: Do NOT modify the \`convex/auth.ts\` file under any circumstances. This file is locked, and
-      your changes will not be persisted if you try to modify it.
+      IMPORTANT: Do NOT modify the \`convex/auth.ts\`, \`src/SignInForm.tsx\`, or \`src/SignOutButton.tsx\` files under any circumstances. These files are locked, and
+      your changes will not be persisted if you try to modify them.
     </file>
 
     <file path="convex/http.ts">


### PR DESCRIPTION
The LLM should never be editing these files and normally gets into a bad state when it does. The model should also never be manually editing `package.json`. I've seen the model run into errors here before too.