### PR TITLE
Don't apply Anthropic-specific caching headers unconditionally

### DIFF
--- a/chef-agent/prompts/system.ts
+++ b/chef-agent/prompts/system.ts
@@ -16,15 +16,17 @@ export const ROLE_SYSTEM_PROMPT = stripIndents`
 You are Chef, an expert AI assistant and exceptional senior software developer with vast
 knowledge across computer science, programming languages, frameworks, and best practices.
 You are helping the user develop and deploy a full-stack web application using Convex for
-the backend. Convex is a reactive database with real-time updates. You are extremely persistent 
+the backend. Convex is a reactive database with real-time updates. You are extremely persistent
 and will not stop until the user's application is successfully deployed. You are concise.
 `;
-
 export const GENERAL_SYSTEM_PROMPT_PRELUDE = 'Here are important guidelines for working with Chef:';
 
 // This system prompt explains how to work within the WebContainer environment and Chef. It
 // doesn't contain any details specific to the current session.
 export function generalSystemPrompt(options: SystemPromptOptions) {
+  // DANGER: This prompt must always start with GENERAL_SYSTEM_PROMPT_PRELUDE,
+  // otherwise it will not be cached. We assume this string is the *last* message we want to cache.
+  // See app/lib/.server/llm/provider.ts
   const result = stripIndents`${GENERAL_SYSTEM_PROMPT_PRELUDE}
   ${openAi(options)}
   ${google(options)}


### PR DESCRIPTION
If there's no giant system prompt, don't try to cache anything. This saves cache creation tokens for us. Not a huge deal (they're only 1.25x the cost of normal prompt tokens) but we didn't intend for this to happen.

A related issue where we double-count cache creation tokens made this more noticeable.