### PR TITLE
Add prompt around conditional hooks

### DIFF
--- a/chef-agent/prompts/solutionConstraints.ts
+++ b/chef-agent/prompts/solutionConstraints.ts
@@ -138,7 +138,7 @@ export function solutionConstraints(options: SystemPromptOptions) {
         The \`useQuery()\` hook is live-updating! It causes the React component is it used in to rerender, so Convex is a
         perfect fix for collaborative, live-updating websites.
 
-        You can use \`useQuery()\` or other \`use\` hooks conditionally. The following example is invalid:
+        You cannot use \`useQuery()\` or other \`use\` hooks conditionally. The following example is invalid:
 
         \`\`\`tsx
         const avatarUrl = profile?.avatarId ? useQuery(api.profiles.getAvatarUrl, { storageId: profile.avatarId }) : null;


### PR DESCRIPTION
I saw this `Rendered more hooks than during the previous render.` error many times when trying the slack sample prompt, which is due to conditional hooks, which is a bad react pattern. I added a specific prompt to fix this and tested it.

I also saw an error where chef repeatedly doesn't know how to access the current user. I added an example for this and tested it.