### PR TITLE
Log successful/failed tool calls

### DIFF
--- a/app/lib/.server/llm/convex-agent.ts
+++ b/app/lib/.server/llm/convex-agent.ts
@@ -208,7 +208,8 @@ async function onFinishHandler({
     if (result.finishReason === 'stop') {
       const lastMessage = messages[messages.length - 1];
       if (lastMessage.role === 'assistant') {
-        // This field is deprecated, but for some reason, the new field "parts", does not contain all of the tool calls.
+        // This field is deprecated, but for some reason, the new field "parts", does not contain all of the tool calls. This is likely a
+        // vercel bug. We do this at the end end the request because it's when we have the results from all of the tool calls.
         const toolCalls = lastMessage.toolInvocations?.filter((t) => t.toolName === 'deploy' && t.state === 'result');
         const successfulDeploys =
           toolCalls?.filter((t) => t.state === 'result' && !t.result.startsWith('Error:')).length ?? 0;


### PR DESCRIPTION
Log all tool calls when the LLM finishes with the `stop` finish reason.

I had to use a deprecated field because the new field is not populated properly.