### PR TITLE
Fix reload bug

### DIFF
--- a/app/components/chat/Chat.tsx
+++ b/app/components/chat/Chat.tsx
@@ -352,6 +352,7 @@ export const Chat = memo(
           nextRetry: Date.now() + backoff,
         });
 
+        workbenchStore.abortAllActions();
         if (isFirstFailure && messages[messages.length - 1].role === 'user') {
           reload();
         }


### PR DESCRIPTION
The `reload()` function regenerates the LLM's whole turn, so we only want to do this if the last message is the user's message. Otherwise, we should have the user resend their request.

Tested that this works locally

Fixes ENG-9155