### PR TITLE
Fix issue with anonymous users

### DIFF
--- a/chef-agent/prompts/solutionConstraints.ts
+++ b/chef-agent/prompts/solutionConstraints.ts
@@ -138,7 +138,7 @@ export function solutionConstraints(options: SystemPromptOptions) {
         The \`useQuery()\` hook is live-updating! It causes the React component is it used in to rerender, so Convex is a
         perfect fix for collaborative, live-updating websites.
 
-        You cannot use \`useQuery()\` or other \`use\` hooks conditionally. The following example is invalid:
+        NEVER use \`useQuery()\` or other \`use\` hooks conditionally. The following example is invalid:
 
         \`\`\`tsx
         const avatarUrl = profile?.avatarId ? useQuery(api.profiles.getAvatarUrl, { storageId: profile.avatarId }) : null;
@@ -164,6 +164,8 @@ export function solutionConstraints(options: SystemPromptOptions) {
         You can use the \`api\` object to call any public Convex function.
 
         Always use \`canvas\` for image compression.
+
+        Always make sure your UIs work well with anonymous users.
       </client_guidelines>
     </convex_guidelines>
   </solution_constraints>


### PR DESCRIPTION
Turns out that the issue with not seeing messages was related to being an anonymous user. So, I added a prompt to make UIs better for anonymous users. Essentially, the messages wouldn't render if the user didn't have a profile name.

Tested this with like 5 slacks locally and the other prompts and things are working well.