### PR TITLE
Don't cache tool definitions

### DIFF
--- a/app/lib/.server/llm/provider.ts
+++ b/app/lib/.server/llm/provider.ts
@@ -274,8 +274,6 @@ function anthropicInjectCacheControl(options?: RequestInit) {
   }
 
   const body = JSON.parse(options.body);
-  // Cache tool definitions.
-  body.tools[body.tools.length - 1].cache_control = { type: 'ephemeral' };
 
   // Cache system prompt.
   body.system[body.system.length - 1].cache_control = { type: 'ephemeral' };


### PR DESCRIPTION
`tools` is sometimes undefined, and our tool definitions don't even hit the minimum token length to be cached, so we should not cache them. I think this is at least one cause of getting 0 cache reads, since tools come before the system prompt in the cache prefix.