### PR TITLE
Cache for BYO anthropic API key

### DIFF
--- a/app/lib/.server/llm/provider.ts
+++ b/app/lib/.server/llm/provider.ts
@@ -200,13 +200,8 @@ const userKeyApiFetch = (provider: ModelProvider) => {
   const fetch = undiciFetch as unknown as Fetch;
 
   return async (input: RequestInfo | URL, init?: RequestInit) => {
-    let result: Response;
-    if (provider === 'Anthropic') {
-      const enrichedOptions = anthropicInjectCacheControl(init);
-      result = await fetch(input, enrichedOptions);
-    } else {
-      result = await fetch(input, init);
-    }
+    const requestInit = provider === 'Anthropic' ? anthropicInjectCacheControl(init) : init;
+    const result = await fetch(input, requestInit);
     if (result.status === 401) {
       const text = await result.text();
       throw new Error(JSON.stringify({ error: 'Invalid API key', details: text }));


### PR DESCRIPTION
We weren't injecting the `cache_control` blocks into requests that use the user's own API key. This fixes.