### PR TITLE
Sync message cutoff with relevant files

### DIFF
--- a/chef-agent/ChatContextManager.ts
+++ b/chef-agent/ChatContextManager.ts
@@ -55,7 +55,7 @@ export class ChatContextManager {
     // Only update the relevant files and the message cutoff indices if the last message is a user message to avoid clearing the cache as the agent makes changes.
     if (messages[messages.length - 1].role === 'user') {
       this.initialRelevantFiles = this.relevantFiles(messages, maxRelevantFilesSize);
-      const [iCutoff, jCutoff] = this.messagePartCutoff(messages, 1000);
+      const [iCutoff, jCutoff] = this.messagePartCutoff(messages, maxCollapsedMessagesSize);
       this.messageICutoff = iCutoff;
       this.messageJCutoff = jCutoff;
     }


### PR DESCRIPTION
This change keeps the relevant files in sync with the number of messages from the chat history we send up - updating both when there is a new user message. This should help us get cache hits on messages.