### PR TITLE
Add retries on set env failures

### DIFF
--- a/app/lib/stores/startup/useContainerSetup.ts
+++ b/app/lib/stores/startup/useContainerSetup.ts
@@ -13,7 +13,7 @@ import { toast } from 'sonner';
 import { waitForConvexProjectConnection } from '~/lib/stores/convexProject';
 import type { ConvexProject } from 'chef-agent/types';
 import type { WebContainer } from '@webcontainer/api';
-import { queryEnvVariable, setEnvVariables } from 'chef-agent/convexEnvVariables';
+import { queryEnvVariable, setEnvVariablesWithRetries } from 'chef-agent/convexEnvVariables';
 import { getConvexSiteUrl } from '~/lib/convexSiteUrl';
 import { workbenchStore } from '~/lib/stores/workbench.client';
 import { initializeConvexAuth } from 'chef-agent/convexAuth';
@@ -154,7 +154,7 @@ async function setupOpenAIToken(convex: ConvexReactClient, project: ConvexProjec
   }
   const token = await convex.mutation(api.openaiProxy.issueOpenAIToken);
   if (token) {
-    await setEnvVariables(project, {
+    await setEnvVariablesWithRetries(project, {
       CONVEX_OPENAI_API_KEY: token,
       CONVEX_OPENAI_BASE_URL: getConvexSiteUrl() + '/openai-proxy',
     });
@@ -168,7 +168,7 @@ async function setupResendToken(convex: ConvexReactClient, project: ConvexProjec
   }
   const token = await convex.mutation(api.resendProxy.issueResendToken);
   if (token) {
-    await setEnvVariables(project, {
+    await setEnvVariablesWithRetries(project, {
       CONVEX_RESEND_API_KEY: token,
       RESEND_BASE_URL: getConvexSiteUrl() + '/resend-proxy',
     });

--- a/chef-agent/convexAuth.ts
+++ b/chef-agent/convexAuth.ts
@@ -1,6 +1,6 @@
 import { generateKeyPair, exportPKCS8, exportJWK } from 'jose';
 import type { ConvexProject } from './types.js';
-import { queryEnvVariable, setEnvVariables } from './convexEnvVariables.js';
+import { queryEnvVariable, setEnvVariablesWithRetries } from './convexEnvVariables.js';
 import { logger } from './utils/logger.js';
 
 export async function initializeConvexAuth(project: ConvexProject) {
@@ -26,7 +26,7 @@ export async function initializeConvexAuth(project: ConvexProject) {
     newEnv.SITE_URL = 'http://localhost:5173';
   }
   if (Object.entries(newEnv).length > 0) {
-    await setEnvVariables(project, newEnv);
+    await setEnvVariablesWithRetries(project, newEnv);
   }
   logger.info('✅ Convex Auth setup!');
 }


### PR DESCRIPTION
We have been seeing the env variable query fail when we are starting a container. This adds retries to make it more resilient. We could maybe add expo backoff here instead, but i decided to do the simple thing.