### PR TITLE
Fix horizontal overflow on landing page

### DIFF
--- a/app/components/landing/tweets/HorizontalCarousel.tsx
+++ b/app/components/landing/tweets/HorizontalCarousel.tsx
@@ -12,7 +12,7 @@ export default function HorizontalCarousel({ tweets, className = '' }: Horizonta
   const [emblaRef] = useEmblaCarousel({ align: 'center', loop: true });
 
   return (
-    <div className={classNames('relative -mx-8 overflow-hidden', className)}>
+    <div className={classNames('relative overflow-hidden', className)}>
       <div className="pointer-events-none absolute left-0 top-0 z-10 h-full w-8 bg-gradient-to-r to-transparent dark:from-[var(--bolt-elements-bg-depth-1)]" />
       <div className="pointer-events-none absolute right-0 top-0 z-10 h-full w-8 bg-gradient-to-l to-transparent dark:from-[var(--bolt-elements-bg-depth-1)]" />
       <div ref={emblaRef} style={{ WebkitOverflowScrolling: 'touch' }}>


### PR DESCRIPTION
Quick fix to remove horizontal overflow from the landing page. It was originally extended full-bleed to make room for the gradient before the first tweet, but now that the tweets are aligned to the center it's not necessary to maximize the width.

![image](https://github.com/user-attachments/assets/819eb8c3-ec38-4b70-86c6-59a03c9c1d58)
