### PR TITLE
Prevent workbench from covering scrollbar

### DIFF
--- a/app/components/workbench/Workbench.client.tsx
+++ b/app/components/workbench/Workbench.client.tsx
@@ -178,7 +178,7 @@ export const Workbench = memo(function Workbench({
         >
           <div
             className={classNames(
-              'fixed top-[calc(var(--header-height)+1rem)] bottom-four w-[var(--workbench-inner-width)] mr-4 z-0 transition-[left,width] duration-200 bolt-ease-cubic-bezier',
+              'fixed top-[calc(var(--header-height)+1rem)] bottom-four w-[var(--workbench-inner-width)] z-0 transition-[left,width] duration-200 bolt-ease-cubic-bezier',
               {
                 'w-full': isSmallViewport,
                 'left-0': showWorkbench && isSmallViewport,
@@ -187,7 +187,7 @@ export const Workbench = memo(function Workbench({
               },
             )}
           >
-            <div className="absolute inset-0 px-2 lg:px-6">
+            <div className="absolute inset-0 px-2">
               <div className="flex h-full flex-col overflow-hidden rounded-lg border bg-bolt-elements-background-depth-2 shadow-sm">
                 <div className="flex items-center border-b px-3 py-2">
                   <Slider selected={selectedView} options={sliderOptions} setSelected={setSelectedView} />

--- a/app/styles/variables.css
+++ b/app/styles/variables.css
@@ -251,7 +251,7 @@ html.dark {
   --chat-max-width: 37rem;
   --chat-min-width: 640px;
   --workbench-width: min(calc(100% - var(--chat-min-width)), 2536px);
-  --workbench-inner-width: var(--workbench-width);
+  --workbench-inner-width: calc(var(--workbench-width) - 16px);
   --workbench-left: calc(100% - var(--workbench-width));
 
   /* Terminal */


### PR DESCRIPTION
The workbench/preview currently has margin and padding that increase its width, capturing scroll events and blocking the user from clicking the scrollbar for the underlying page.

https://github.com/user-attachments/assets/595448ea-fdf2-4725-bf68-baf1b6b5f8e5

(Note the tiny area above the preview where the scrollbar can be clicked)

This PR reduces the margin and padding on the workbench, and adjusts the `--workbench-inner-width` CSS variable to keep the workbench the same size, while ensuring there isn't a transparent area covering the scrollbar.

https://github.com/user-attachments/assets/5ef4da0e-3177-400a-96c3-d2de643e1b07