### PR TITLE
Mitigate common errors

### DIFF
--- a/chef-agent/constants.ts
+++ b/chef-agent/constants.ts
@@ -15,7 +15,6 @@ export const SUGGESTIONS = [
     prompt: `Build an app similar to Instagram with a global shared image stream that has these features:
 
 - Has a drag and drop box for uploading images to Convex storage
-- Automatically resizes uploaded images to max 800x800 and crops to square
 - Has a "Stream" tab for viewing the global image stream
 - Has a "My Photos" tab for viewing and deleting your own images
 - Allows liking images in the "Stream" tab

--- a/chef-agent/prompts/convexGuidelines.ts
+++ b/chef-agent/prompts/convexGuidelines.ts
@@ -175,13 +175,13 @@ export const g = query({
 ### Function references
 
 - Function references are pointers to registered Convex functions.
-- ALWAYS use the \`api\` object defined by the framework in \`convex/_generated/api.ts\` to call public functions registered with \`query\`, \`mutation\`, or \`action\`. Importing the \`api\` object looks like:
+- ALWAYS use the \`api\` object defined by the framework in \`convex/_generated/api.ts\` to call public functions registered with \`query\`, \`mutation\`, or \`action\`. You must import the \`api\` object in the same file when using it and it looks like:
 
 \`\`\`ts
 import { api } from "./_generated/api";
 \`\`\`
 
-- ALWAYS use the \`internal\` object defined by the framework in \`convex/_generated/api.ts\` to call internal (or private) functions registered with \`internalQuery\`, \`internalMutation\`, or \`internalAction\`. Importing the \`internal\` object looks like:
+- ALWAYS use the \`internal\` object defined by the framework in \`convex/_generated/api.ts\` to call internal (or private) functions registered with \`internalQuery\`, \`internalMutation\`, or \`internalAction\`. You must import the \`internal\` object in the same file when using it and it looks like:
 
 \`\`\`ts
 import { internal } from "./_generated/api";

--- a/chef-agent/prompts/outputInstructions.ts
+++ b/chef-agent/prompts/outputInstructions.ts
@@ -59,6 +59,10 @@ function artifactInstructions(_options: SystemPromptOptions) {
     IMPORTANT: Write as many files as possible in a single artifact. Do NOT split up the creation of different
     files across multiple artifacts unless absolutely necessary.
 
+    IMPORTANT: Always rewrite the entire file in the artifact. Do not use placeholders like "// rest of the code remains the same..." or "<- leave original code here ->".
+
+    IMPORTANT: Never write empty files. This will cause the old version of the file to be deleted.
+
     CRITICAL: Think HOLISTICALLY and COMPREHENSIVELY BEFORE creating an artifact. This means:
 
       - Consider ALL relevant files in the project

--- a/chef-agent/prompts/solutionConstraints.ts
+++ b/chef-agent/prompts/solutionConstraints.ts
@@ -163,9 +163,13 @@ export function solutionConstraints(options: SystemPromptOptions) {
 
         You can use the \`api\` object to call any public Convex function.
 
-        Always use \`canvas\` for image compression.
+        Do not use \`sharp\` for image compression, always use \`canvas\` for image compression.
 
         Always make sure your UIs work well with anonymous users.
+
+        Always make sure the functions you are calling are defined in the \`convex/\` directory and use the \`api\` or \`internal\` object to call them.
+        
+        Always make sure you are using the correct arguments for convex functions. If arguments are not optional, make sure they are not null.
       </client_guidelines>
     </convex_guidelines>
   </solution_constraints>

--- a/chef-agent/tools/deploy.ts
+++ b/chef-agent/tools/deploy.ts
@@ -12,7 +12,8 @@ to the filesystem.
 
 If this tool call fails with esbuild bundler errors, a library that requires Node.js
 APIs may be being used. Isolating those dependencies into a convex file of only actions
-with "use node" at the top is a way to fix this.
+with "use node" at the top is the only way to fix this. The files with "use node" at the
+top can only contain actions. They can NEVER contains queries or mutations.
 `;
 
 export const deployTool: Tool = {


### PR DESCRIPTION
Adds prompting to mitigate the following common errors:
- passing in optional arguments to a convex function that doesn't have optional arguments
- rewriting files as empty
- "rest of the code stays the same" comments
- failing to add "use node" correctly