### PR TITLE
Fix repeated failed tool calls

### DIFF
--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -32,3 +32,5 @@ export type ModelSelection =
   | 'gpt-4.1-mini'
   | 'grok-3-mini'
   | 'gemini-2.5-pro';
+
+export const MAX_CONSECUTIVE_DEPLOY_ERRORS = 5;


### PR DESCRIPTION
After a tool call fails, the system would only be able to make one more deploy before failing again. This was happening because we were just counting the total # of consecutive failed deploys even if they were in different messages. This change simplifies the code by only checking the current message for failed deploys. if the most recent assistant message has more than the allowed failed deploys, then we show disable the tools.

I tested this locally to confirm that this works as expected.