### PR TITLE
Terminate Braintrust on failure

### DIFF
--- a/.github/workflows/daily_evals.yml
+++ b/.github/workflows/daily_evals.yml
@@ -24,4 +24,4 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
-        run: cd test-kitchen && npx braintrust eval initialGeneration.eval.ts
+        run: cd test-kitchen && npx braintrust eval initialGeneration.eval.ts --terminate-on-failure


### PR DESCRIPTION
Currently Braintrust will `exit(0)` when the eval fails to compile (e.g. https://github.com/get-convex/chef/actions/runs/15195895582 which shows a green tick while there is a module loading error). I think that we’re supposed to use `--terminate-on-failure` here? But I’m not 100% sure, since this could also mean that we’re exiting when the eval compiles but then the LLM doesn’t output a valid result 🤔 

```
  --terminate-on-failure
                        If provided, terminates on a failing eval, instead of the default (moving onto the next one).
```