### PR TITLE
[Evals] Add more steps

### DIFF
--- a/chef-agent/prompts/convexGuidelines.ts
+++ b/chef-agent/prompts/convexGuidelines.ts
@@ -915,6 +915,7 @@ Convex Components are like mini self-contained Convex backends, and installing t
 Each component is installed as its own independent library from NPM. You also need to add a \`convex.config.ts\` file that includes the component.
 ALWAYS prefer using a component for a feature than writing the code yourself.
 ALWAYS use the \`lookupDocs\` tool to lookup documentation for a component before trying to use the \`npmInstall\` tool to install the relevant dependencies.
+You DO NOT need to deploy a component to use it. You can use it after you've installed it.
 
 Convex has the following components:
 - \`proseMirror\`: A collaborative text editor component.


### PR DESCRIPTION
- increases the number of steps allowed now that we do edits
- creates a hard stop on 10 deploys
- adds a small comment around `components` to mitigate some errors i've been seeing in evals where it tries to use a component only after its deployed
- updates the deploy logic/output to more closely mirror what we do in production with `[ConvexTypecheck]` and `[FrontendTypecheck]`

With these changes, I saw the evals consistently work on all of the prompts.