### PR TITLE
add full text search to notion clone prompt

### DIFF
--- a/app/components/chat/SuggestionButtons.tsx
+++ b/app/components/chat/SuggestionButtons.tsx
@@ -30,6 +30,7 @@ export const SuggestionButtons = ({ chatStarted, onSuggestionClick, disabled }: 
 - Private documents (only visible to the creator)
 - Public documents (visible to all users)
 - Simple sidebar navigation between documents
+- Full text search over document titles
 - Interface:
 - Clean, minimal design with lots of white space and a neutral color palette (soft grays and whites)
 - Focus on readable text and minimal distractions`,

--- a/chef-agent/constants.ts
+++ b/chef-agent/constants.ts
@@ -43,6 +43,7 @@ export const SUGGESTIONS = [
 - Private documents (only visible to the creator)
 - Public documents (visible to all users)
 - Simple sidebar navigation between documents
+- Full text search over document titles
 - Interface:
 - Clean, minimal design with lots of white space and a neutral color palette (soft grays and whites)
 - Focus on readable text and minimal distractions`,


### PR DESCRIPTION
Search over document titles works well, but can't really be extended to document content because the component doesn't expose that (and would have trouble exposing that because of the way data is split between snapshots and deltas).