### PR TITLE
Only run evals on PR to release

### DIFF
--- a/.github/workflows/staging_evals.yml
+++ b/.github/workflows/staging_evals.yml
@@ -2,9 +2,7 @@ name: Run braintrust evals
 
 on:
   pull_request:
-    branches: [staging]
-  push:
-    branches: [staging]
+    branches: [release]
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
The rules were wrong. Still trying to debug why the gpt-4.1 eval is running even though the env var isn't set.