### PR TITLE
[Evals] Manually check if we want to use openai

### DIFF
--- a/.github/workflows/daily_evals.yml
+++ b/.github/workflows/daily_evals.yml
@@ -24,4 +24,5 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+          USE_OPENAI: true
         run: cd test-kitchen && npx braintrust eval initialGeneration.eval.ts

--- a/.github/workflows/staging_evals.yml
+++ b/.github/workflows/staging_evals.yml
@@ -26,6 +26,7 @@ jobs:
           BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
+          USE_OPENAI: false
         uses: braintrustdata/eval-action@v1
         with:
           api_key: ${{ secrets.BRAINTRUST_API_KEY }}

--- a/test-kitchen/initialGeneration.eval.ts
+++ b/test-kitchen/initialGeneration.eval.ts
@@ -57,7 +57,9 @@ if (process.env.ANTHROPIC_API_KEY) {
   });
 }
 
-if (process.env.OPENAI_API_KEY) {
+// Braintrust sets the OPENAI_API_KEY environment variable even if we don't set it, so we need
+// to manually check the USE_OPENAI environment variable to determine if we should use OpenAI.
+if (process.env.OPENAI_API_KEY && process.env.USE_OPENAI === 'true') {
   chefEval({
     name: 'gpt-4.1',
     model_slug: 'gpt-4.1',


### PR DESCRIPTION
Braintrust automatically sets the `OPENAI_API_KEY` even if we don't set it ourselves, so we need to read another variable to see if we actually want to use them or not in a specific eval.