### PR TITLE
[Evals] Run hourly instead of daily

### DIFF
--- a/.github/workflows/daily_evals.yml
+++ b/.github/workflows/daily_evals.yml
@@ -2,7 +2,7 @@ name: Daily Evals
 
 on:
   schedule:
-    - cron: '0 0 * * *' # Run at midnight UTC daily
+    - cron: '0 * * * *' # Run at the start of every hour UTC
   workflow_dispatch: # Allow manual triggering
 
 jobs:


### PR DESCRIPTION
This will give us a better signal on how chef is performing/how prompt changes are affecting performance.