### PR TITLE
WIP - New Topic summarization

### DIFF
--- a/app/components/ExistingChat.client.tsx
+++ b/app/components/ExistingChat.client.tsx
@@ -31,8 +31,13 @@ export function ExistingChat({ chatId }: { chatId: string }) {
 
 function ExistingChatWrapper({ chatId }: { chatId: string }) {
   const sessionId = useStore(sessionIdStore);
-  const { initialMessages, storeMessageHistory, initializeChat, earliestRewindableMessageRank } =
-    useConvexChatExisting(chatId);
+  const {
+    initialMessages,
+    initialSummarizationMessageIndices,
+    storeMessageHistory,
+    initializeChat,
+    earliestRewindableMessageRank,
+  } = useConvexChatExisting(chatId);
 
   const reloadState = useReloadMessages(initialMessages ?? undefined);
   const bootState = useContainerBootState();
@@ -88,6 +93,7 @@ function ExistingChatWrapper({ chatId }: { chatId: string }) {
       {!loading && (
         <Chat
           initialMessages={initialMessages!}
+          initialSummarizationMessageIndices={initialSummarizationMessageIndices}
           partCache={reloadState!.partCache}
           storeMessageHistory={storeMessageHistory}
           initializeChat={initializeChat}

--- a/app/components/Homepage.client.tsx
+++ b/app/components/Homepage.client.tsx
@@ -33,6 +33,7 @@ const ChatWrapper = ({ initialId }: { initialId: string }) => {
   return (
     <Chat
       initialMessages={emptyList}
+      initialSummarizationMessageIndices={emptyIndices}
       partCache={partCache.current}
       storeMessageHistory={storeMessageHistory}
       initializeChat={initializeChat}
@@ -44,3 +45,4 @@ const ChatWrapper = ({ initialId }: { initialId: string }) => {
 };
 
 const emptyList: Message[] = [];
+const emptyIndices: number[] = [];

--- a/app/components/chat/AssistantMessage.tsx
+++ b/app/components/chat/AssistantMessage.tsx
@@ -11,9 +11,10 @@ import { captureMessage } from '@sentry/remix';
 
 interface AssistantMessageProps {
   message: Message;
+  isSummary: boolean;
 }
 
-export const AssistantMessage = memo(function AssistantMessage({ message }: AssistantMessageProps) {
+export const AssistantMessage = memo(function AssistantMessage({ message, isSummary }: AssistantMessageProps) {
   const { showUsageAnnotations } = useLaunchDarkly();
   const parsedAnnotations = useMemo(() => parseAnnotations(message.annotations), [message.annotations]);
   if (!message.parts) {

--- a/app/components/chat/BaseChat.client.tsx
+++ b/app/components/chat/BaseChat.client.tsx
@@ -58,6 +58,9 @@ interface BaseChatProps {
   // Rewind functionality
   onRewindToMessage?: (index: number) => void;
   earliestRewindableMessageRank?: number;
+
+  // messages which could possibly be collapsed
+  summarizationMessageIndices: number[];
 }
 
 export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
@@ -82,11 +85,11 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
       setModelSelection,
       onRewindToMessage,
       earliestRewindableMessageRank,
+      summarizationMessageIndices,
     },
     ref,
   ) => {
     const { maintenanceMode } = useLaunchDarkly();
-
     const isStreaming = streamStatus === 'streaming' || streamStatus === 'submitted';
     const recommendedExperience = chooseExperience(navigator.userAgent, window.crossOriginIsolated);
     const [chatEnabled, setChatEnabled] = useState(recommendedExperience === 'the-real-thing');
@@ -154,6 +157,7 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
                     isStreaming={isStreaming}
                     onRewindToMessage={onRewindToMessage}
                     earliestRewindableMessageRank={earliestRewindableMessageRank}
+                    summarizationMessageIndices={summarizationMessageIndices}
                   />
                 ) : null}
                 <div

--- a/app/components/chat/MessageInput.tsx
+++ b/app/components/chat/MessageInput.tsx
@@ -34,6 +34,7 @@ import { captureException } from '@sentry/remix';
 import { Menu as MenuComponent, MenuItem as MenuItemComponent } from '@ui/Menu';
 import { PencilSquareIcon } from '@heroicons/react/24/outline';
 import { ChatBubbleLeftIcon, DocumentArrowUpIcon, InformationCircleIcon } from '@heroicons/react/24/outline';
+import { NewTopicButton } from './NewTopicButton.client';
 
 const PROMPT_LENGTH_WARNING_THRESHOLD = 2000;
 
@@ -303,11 +304,16 @@ export const MessageInput = memo(function MessageInput({
               </MenuItemComponent>
             </MenuComponent>
             {chefAuthState.kind === 'fullyLoggedIn' && (
-              <EnhancePromptButton
-                isEnhancing={isEnhancing}
-                disabled={!selectedTeamSlug || disabled || input.length === 0}
-                onClick={enhancePrompt}
-              />
+              <>
+                <EnhancePromptButton
+                  isEnhancing={isEnhancing}
+                  disabled={!selectedTeamSlug || disabled || input.length === 0}
+                  onClick={enhancePrompt}
+                />
+                <NewTopicButton
+                  disabled={!selectedTeamSlug || disabled || input.length === 0 || sendMessageInProgress || isStreaming}
+                />
+              </>
             )}
             <Button
               disabled={

--- a/app/components/chat/NewTopicButton.client.tsx
+++ b/app/components/chat/NewTopicButton.client.tsx
@@ -1,0 +1,44 @@
+import { Button } from '@ui/Button';
+import React, { useCallback, useState } from 'react';
+import { Spinner } from '@ui/Spinner';
+import { BookOpenIcon } from '@heroicons/react/24/outline';
+
+interface NewTopicButtonProps {
+  disabled?: boolean;
+}
+
+export const NewTopicButton = React.memo(function EnhancePromptButton({ disabled }: NewTopicButtonProps) {
+  const [isSummarizing, setIsSummarizing] = useState(false);
+  const summarizeConversation = useCallback(async () => {
+    setIsSummarizing(true);
+    /**
+     * - Make an LLM call (for free?) to summarize the conversation so far.
+     * - Add a user message, but dont' actually send it? Or write some parts
+     *   that are ready to be added as parts to the next user message.
+     *
+     * What's the data transformation we want to make here? How about the *only* thing that
+     * happens is that we add a number somewhere.
+     *
+     * Then once the next chat message is submitted, that's the time to actually do the
+     * and add additional parts onto the user message.
+     *
+     *
+     */
+    await new Promise((r) => setTimeout(r, 1000));
+    setIsSummarizing(false);
+  }, []);
+
+  return (
+    <Button
+      variant="neutral"
+      tip={'Summarize the conversation so far'}
+      disabled={disabled}
+      inline
+      onClick={summarizeConversation}
+    >
+      <div className="text-lg">
+        {!isSummarizing ? <BookOpenIcon className="size-4" /> : <Spinner className="size-4" />}
+      </div>
+    </Button>
+  );
+});

--- a/app/lib/stores/startup/index.ts
+++ b/app/lib/stores/startup/index.ts
@@ -33,5 +33,6 @@ export function useConvexChatExisting(chatId: string) {
     initializeChat,
     storeMessageHistory,
     earliestRewindableMessageRank: initialMessages?.earliestRewindableMessageRank,
+    initialSummarizationMessageIndices: !initialMessages ? [] : initialMessages.summarizationMessageIndices,
   };
 }

--- a/app/lib/stores/startup/useInitialMessages.ts
+++ b/app/lib/stores/startup/useInitialMessages.ts
@@ -16,6 +16,7 @@ export interface InitialMessages {
   serialized: SerializedMessage[];
   deserialized: Message[];
   earliestRewindableMessageRank?: number;
+  summarizationMessageIndices: number[];
 }
 
 export function useInitialMessages(chatId: string):
@@ -24,6 +25,7 @@ export function useInitialMessages(chatId: string):
   | undefined {
   const convex = useConvex();
   const [initialMessages, setInitialMessages] = useState<InitialMessages | null | undefined>();
+  console.log('initialMessage:', initialMessages?.summarizationMessageIndices);
   useEffect(() => {
     const loadInitialMessages = async () => {
       const sessionId = await waitForConvexSessionId('loadInitialMessages');
@@ -94,6 +96,7 @@ export function useInitialMessages(chatId: string):
           serialized: transformedMessages,
           deserialized: deserializedMessages,
           earliestRewindableMessageRank: earliestRewindableMessageRank ?? undefined,
+          summarizationMessageIndices: chatInfo.summarizationMessageIndices,
         });
         description.set(chatInfo.description);
       } catch (error) {

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -114,6 +114,7 @@ export async function getChat(ctx: QueryCtx, id: string, sessionId: Id<"sessions
     description: chat.description,
     timestamp: chat.timestamp,
     snapshotId: chat.snapshotId,
+    summarizationMessageIndices: chat.summarizationMessageIndices || [],
   };
 }
 
@@ -130,6 +131,7 @@ export const get = query({
       description: v.optional(v.string()),
       timestamp: v.string(),
       snapshotId: v.optional(v.id("_storage")),
+      summarizationMessageIndices: v.array(v.number()),
     }),
   ),
   handler: async (ctx, args) => {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -73,8 +73,11 @@ export default defineSchema({
     urlId: v.optional(v.string()),
     description: v.optional(v.string()),
     timestamp: v.string(),
+    // The messages at these indices are summaries of all previous messages.
+    summarizationMessageIndices: v.optional(v.array(v.number())),
     metadata: v.optional(v.any()), // TODO migration to remove this column
     snapshotId: v.optional(v.id("_storage")),
+    // leftover from a migration? no longer used
     lastMessageRank: v.optional(v.number()),
     hasBeenDeployed: v.optional(v.boolean()),
     isDeleted: v.optional(v.boolean()),


### PR DESCRIPTION
Gist is clicking a new button should
- Send a message asking the LLM to summarize the conversation so far
- Receive a message from teh assistant that is the summary
- add the index of that message to an array of summarization messages
- ContextManager should not send all messages before the last summarization message
- ContextManager should include relevant files at this point

Then when displaying messages, messages before a summarization message should be hidden. It's possible to expand them by clicking something. These messages are still passed to the Vercel AI SDK useChat() hook, ContextManager just knows to disable them.

Right now you can add an index manually in the dashboard and the previous messages are indeed shown collapsed. To do:

- Add UI for starting a "new topic"
- add local state for these summarization message indices
- modify local state when requesting a summarization message
- persist this state along with messages when saving messages to Convex
- Add UI for expanding previous messages
