### PR TITLE
[Evals] Don't run gemini on release

### DIFF
--- a/.github/workflows/staging_evals.yml
+++ b/.github/workflows/staging_evals.yml
@@ -25,7 +25,6 @@ jobs:
           ENVIRONMENT: ci
           BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
           USE_OPENAI: false
         uses: braintrustdata/eval-action@v1
         with:


### PR DESCRIPTION
We no longer expect this to work. Gemini has not been performing well.