### PR TITLE
Gemini 2.5 Pro no longer recommended

### DIFF
--- a/app/components/chat/ModelSelector.tsx
+++ b/app/components/chat/ModelSelector.tsx
@@ -89,7 +89,7 @@ export const models: Partial<
   },
   'gemini-2.5-pro': {
     name: 'Gemini 2.5 Pro',
-    recommended: true,
+    recommended: false,
     provider: 'google',
   },
   'gpt-4.1': {


### PR DESCRIPTION
Gemini 2.5 Pro hasn't been performing well as of late, so we should no longer recommend it to our users.