### PR TITLE
[Evals] Reduce frequency

### DIFF
--- a/.github/workflows/daily_evals.yml
+++ b/.github/workflows/daily_evals.yml
@@ -2,7 +2,7 @@ name: Daily Evals
 
 on:
   schedule:
-    - cron: '0 * * * *' # Run at the start of every hour UTC
+    - cron: '0 */8 * * *' # Run 3 times a day
   workflow_dispatch: # Allow manual triggering
 
 jobs:
@@ -21,8 +21,6 @@ jobs:
           ENVIRONMENT: ci
           BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
-          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
-          USE_OPENAI: true
+          USE_OPENAI: false
         run: cd test-kitchen && npx braintrust eval initialGeneration.eval.ts


### PR DESCRIPTION
Reduces the frequency of evals from hourly to 3 times per day. We also remove the grok and openai models because they haven't been performing well and don't provide us much value.