### PR TITLE
[New Feature Button] Update data model + add migrations

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -118,7 +118,7 @@ httpWithCors.route({
     const sessionId = url.searchParams.get("sessionId");
     const chatId = url.searchParams.get("chatId");
     const lastMessageRank = url.searchParams.get("lastMessageRank");
-    const lastSubchatId = url.searchParams.get("lastSubchatId");
+    const lastSubchatIndex = url.searchParams.get("lastSubchatIndex");
     const partIndex = url.searchParams.get("partIndex");
     const formData = await request.formData();
     let messageStorageId: Id<"_storage"> | null = null;
@@ -136,7 +136,7 @@ httpWithCors.route({
       chatId: chatId as Id<"chats">,
       lastMessageRank: parseInt(lastMessageRank!),
       // Default to the first feature if not provided
-      subchatId: parseInt(lastSubchatId ?? "0"),
+      subchatIndex: parseInt(lastSubchatIndex ?? "0"),
       partIndex: parseInt(partIndex!),
       storageId: messageStorageId,
       snapshotId: snapshotStorageId,

--- a/convex/messages.test.ts
+++ b/convex/messages.test.ts
@@ -48,7 +48,7 @@ async function assertStorageInfo(
     expectedSnapshotContent: string | null;
     expectedLastMessageRank: number;
     expectedPartIndex: number;
-    expectedSubchatId?: number;
+    expectedSubchatIndex?: number;
   },
 ): Promise<void> {
   expect(storageInfo).not.toBeNull();
@@ -76,7 +76,7 @@ async function assertStorageInfo(
   }
   expect(storageInfo.lastMessageRank).toBe(options.expectedLastMessageRank);
   expect(storageInfo.partIndex).toBe(options.expectedPartIndex);
-  expect(storageInfo.subchatId).toBe(options.expectedSubchatId);
+  expect(storageInfo.subchatIndex).toBe(options.expectedSubchatIndex);
 }
 
 async function createSocialShare(t: TestConvex, chatId: string, sessionId: Id<"sessions">, code: string = "test123") {
@@ -139,7 +139,7 @@ describe("messages", () => {
       expectedSnapshotContent: null,
       expectedLastMessageRank: 0,
       expectedPartIndex: 0,
-      expectedSubchatId: 0,
+      expectedSubchatIndex: 0,
     });
   });
 
@@ -180,7 +180,7 @@ describe("messages", () => {
       expectedSnapshotContent: null,
       expectedLastMessageRank: 0,
       expectedPartIndex: 0,
-      expectedSubchatId: 0,
+      expectedSubchatIndex: 0,
     });
 
     const secondMessage: SerializedMessage = createMessage({
@@ -201,7 +201,7 @@ describe("messages", () => {
       expectedSnapshotContent: null,
       expectedLastMessageRank: 1,
       expectedPartIndex: 0,
-      expectedSubchatId: 0,
+      expectedSubchatIndex: 0,
     });
 
     // Should still have both message states in the table
@@ -233,7 +233,7 @@ describe("messages", () => {
       expectedSnapshotContent: initialSnapshotContent,
       expectedLastMessageRank: 0,
       expectedPartIndex: 0,
-      expectedSubchatId: 0,
+      expectedSubchatIndex: 0,
     });
 
     // Store second message without snapshot - should keep the old snapshot ID
@@ -255,7 +255,7 @@ describe("messages", () => {
       expectedSnapshotContent: initialSnapshotContent,
       expectedLastMessageRank: 1,
       expectedPartIndex: 0,
-      expectedSubchatId: 0,
+      expectedSubchatIndex: 0,
     });
 
     // Store only a new snapshot - should keep the old storage ID
@@ -275,7 +275,7 @@ describe("messages", () => {
       expectedSnapshotContent: updatedSnapshotContent,
       expectedLastMessageRank: 1,
       expectedPartIndex: 0,
-      expectedSubchatId: 0,
+      expectedSubchatIndex: 0,
     });
 
     // Should have all states in the table
@@ -307,7 +307,7 @@ describe("messages", () => {
       expectedSnapshotContent: initialSnapshotContent,
       expectedLastMessageRank: 0,
       expectedPartIndex: 0,
-      expectedSubchatId: 0,
+      expectedSubchatIndex: 0,
     });
     const secondMessage: SerializedMessage = createMessage({
       role: "user",
@@ -330,7 +330,7 @@ describe("messages", () => {
       expectedSnapshotContent: updatedSnapshotContent,
       expectedLastMessageRank: 1,
       expectedPartIndex: 0,
-      expectedSubchatId: 0,
+      expectedSubchatIndex: 0,
     });
 
     // Should see lower lastMessageRank after rewinding
@@ -344,7 +344,7 @@ describe("messages", () => {
       expectedSnapshotContent: initialSnapshotContent,
       expectedLastMessageRank: 0,
       expectedPartIndex: 0,
-      expectedSubchatId: 0,
+      expectedSubchatIndex: 0,
     });
 
     // Should still have higher lastMessageRank state in the table
@@ -388,7 +388,7 @@ describe("messages", () => {
       expectedSnapshotContent: updatedSnapshotContent,
       expectedLastMessageRank: 1,
       expectedPartIndex: 0,
-      expectedSubchatId: 0,
+      expectedSubchatIndex: 0,
     });
     const preRewindStorageId = preRewindInfo?.storageId;
     const preRewindSnapshotId = preRewindInfo?.snapshotId;
@@ -464,7 +464,7 @@ describe("messages", () => {
       expectedSnapshotContent: updatedSnapshotContent,
       expectedLastMessageRank: 1,
       expectedPartIndex: 0,
-      expectedSubchatId: 0,
+      expectedSubchatIndex: 0,
     });
 
     // Rewind to first message
@@ -496,14 +496,14 @@ describe("messages", () => {
         snapshotId: share?.snapshotId,
         lastMessageRank: share?.lastMessageRank,
         partIndex: share?.partIndex,
-        subchatId: share?.lastSubchatId,
+        subchatIndex: share?.lastSubchatIndex,
       },
       {
         expectedMessages: [firstMessage, secondMessage],
         expectedSnapshotContent: updatedSnapshotContent,
         expectedLastMessageRank: 1,
         expectedPartIndex: 0,
-        expectedSubchatId: 0,
+        expectedSubchatIndex: 0,
       },
     );
 
@@ -516,7 +516,7 @@ describe("messages", () => {
       expectedSnapshotContent: newSnapshotContent,
       expectedLastMessageRank: 1,
       expectedPartIndex: 0,
-      expectedSubchatId: 0,
+      expectedSubchatIndex: 0,
     });
   });
 
@@ -544,7 +544,7 @@ describe("messages", () => {
       expectedSnapshotContent: initialSnapshotContent,
       expectedLastMessageRank: 0,
       expectedPartIndex: 0,
-      expectedSubchatId: 0,
+      expectedSubchatIndex: 0,
     });
 
     // Store second message with the same snapshot (using doNotUpdateMessages to keep the snapshot reference)
@@ -566,7 +566,7 @@ describe("messages", () => {
       expectedSnapshotContent: initialSnapshotContent,
       expectedLastMessageRank: 1,
       expectedPartIndex: 0,
-      expectedSubchatId: 0,
+      expectedSubchatIndex: 0,
     });
 
     // Rewind to first message
@@ -591,7 +591,7 @@ describe("messages", () => {
       expectedSnapshotContent: newSnapshotContent,
       expectedLastMessageRank: 1,
       expectedPartIndex: 0,
-      expectedSubchatId: 0,
+      expectedSubchatIndex: 0,
     });
     // Importantly, the snapshot is still there since it's referenced by the previous chatMessageStorageState
     await assertStorageInfo(t, finalStorageStates[1], {
@@ -599,7 +599,7 @@ describe("messages", () => {
       expectedSnapshotContent: initialSnapshotContent,
       expectedLastMessageRank: 0,
       expectedPartIndex: 0,
-      expectedSubchatId: 0,
+      expectedSubchatIndex: 0,
     });
   });
 

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -162,7 +162,7 @@ export const storageInfo = v.object({
   lastMessageRank: v.number(),
   partIndex: v.number(),
   snapshotId: v.optional(v.id("_storage")),
-  subchatId: v.optional(v.number()),
+  subchatIndex: v.optional(v.number()),
 });
 
 export type StorageInfo = Infer<typeof storageInfo>;
@@ -188,7 +188,7 @@ export const getInitialMessagesStorageInfo = internalQuery({
       lastMessageRank: doc.lastMessageRank,
       partIndex: doc.partIndex,
       snapshotId: doc.snapshotId,
-      subchatId: doc.subchatId,
+      subchatIndex: doc.subchatIndex,
     };
   },
 });
@@ -225,7 +225,7 @@ export const updateStorageState = internalMutation({
     chatId: v.string(),
     storageId: v.union(v.id("_storage"), v.null()),
     lastMessageRank: v.number(),
-    subchatId: v.number(),
+    subchatIndex: v.number(),
     partIndex: v.number(),
     snapshotId: v.optional(v.union(v.id("_storage"), v.null())),
   },
@@ -279,7 +279,7 @@ export const updateStorageState = internalMutation({
       chatId: chat._id,
       storageId,
       lastMessageRank,
-      subchatId: args.subchatId,
+      subchatIndex: args.subchatIndex,
       partIndex,
       // Should we be using null here to distinguish between not having a snapshot and records written before we also recorded snapshots here?
       snapshotId: snapshotId ?? previous.snapshotId,
@@ -627,13 +627,13 @@ export async function createNewChat(
     initialId: id,
     timestamp: new Date().toISOString(),
     isDeleted: false,
-    lastSubchatId: 0,
+    lastSubchatIndex: 0,
   });
   await ctx.db.insert("chatMessagesStorageState", {
     chatId,
     storageId: null,
     lastMessageRank: -1,
-    subchatId: 0,
+    subchatIndex: 0,
     partIndex: -1,
   });
 

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -15,35 +15,35 @@ export const setDefaultDeletedFalse = migrations.define({
 
 export const runSetDefaultDeletedFalse = migrations.runner(internal.migrations.setDefaultDeletedFalse);
 
-export const addLastSubchatId = migrations.define({
+export const addLastSubchatIndex = migrations.define({
   table: "chats",
   migrateOne: async (ctx, doc) => {
-    if (doc.lastSubchatId === undefined) {
-      await ctx.db.patch(doc._id, { lastSubchatId: 0 });
+    if (doc.lastSubchatIndex === undefined) {
+      await ctx.db.patch(doc._id, { lastSubchatIndex: 0 });
     }
   },
 });
 
-export const runAddLastSubchatId = migrations.runner(internal.migrations.addLastSubchatId);
+export const runAddLastSubchatIndex = migrations.runner(internal.migrations.addLastSubchatIndex);
 
-export const addSubchatId = migrations.define({
+export const addSubchatIndex = migrations.define({
   table: "chatMessagesStorageState",
   migrateOne: async (ctx, doc) => {
-    if (doc.subchatId === undefined) {
-      await ctx.db.patch(doc._id, { subchatId: 0 });
+    if (doc.subchatIndex === undefined) {
+      await ctx.db.patch(doc._id, { subchatIndex: 0 });
     }
   },
 });
 
-export const runAddSubchatId = migrations.runner(internal.migrations.addSubchatId);
+export const runAddSubchatIndex = migrations.runner(internal.migrations.addSubchatIndex);
 
-export const addLastSubchatIdToShares = migrations.define({
+export const addLastSubchatIndexToShares = migrations.define({
   table: "shares",
   migrateOne: async (ctx, doc) => {
-    if (doc.lastSubchatId === undefined) {
-      await ctx.db.patch(doc._id, { lastSubchatId: 0 });
+    if (doc.lastSubchatIndex === undefined) {
+      await ctx.db.patch(doc._id, { lastSubchatIndex: 0 });
     }
   },
 });
 
-export const runAddLastSubchatIdToShares = migrations.runner(internal.migrations.addLastSubchatIdToShares);
+export const runAddLastSubchatIndexToShares = migrations.runner(internal.migrations.addLastSubchatIndexToShares);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -76,7 +76,7 @@ export default defineSchema({
     metadata: v.optional(v.any()), // TODO migration to remove this column
     snapshotId: v.optional(v.id("_storage")),
     lastMessageRank: v.optional(v.number()),
-    lastSubchatId: v.optional(v.number()),
+    lastSubchatIndex: v.optional(v.number()),
     hasBeenDeployed: v.optional(v.boolean()),
     isDeleted: v.optional(v.boolean()),
     convexProject: v.optional(
@@ -115,7 +115,7 @@ export default defineSchema({
   chatMessagesStorageState: defineTable({
     chatId: v.id("chats"),
     storageId: v.union(v.id("_storage"), v.null()),
-    subchatId: v.optional(v.number()),
+    subchatIndex: v.optional(v.number()),
     lastMessageRank: v.number(),
     description: v.optional(v.string()),
     partIndex: v.number(),
@@ -141,7 +141,7 @@ export default defineSchema({
     lastMessageRank: v.number(),
 
     // This should not be optional, but we need to migrate it.
-    lastSubchatId: v.optional(v.number()),
+    lastSubchatIndex: v.optional(v.number()),
     partIndex: v.optional(v.number()),
     // The description of the chat at the time the share was created.
     description: v.optional(v.string()),

--- a/convex/share.ts
+++ b/convex/share.ts
@@ -41,7 +41,7 @@ export const create = mutation({
 
       code,
       lastMessageRank: storageState.lastMessageRank,
-      lastSubchatId: storageState.subchatId,
+      lastSubchatIndex: storageState.subchatIndex,
       partIndex: storageState.partIndex,
       description: chat.description,
     });
@@ -235,7 +235,7 @@ export const clone = mutation({
       chatId: clonedChatId,
       storageId: getShare.chatHistoryId,
       lastMessageRank: getShare.lastMessageRank,
-      subchatId: getShare.lastSubchatId,
+      subchatIndex: getShare.lastSubchatIndex,
       partIndex: getShare.partIndex ?? -1,
     });
 


### PR DESCRIPTION
Updates the data model to properly support the new fields described in [this](https://www.notion.so/convex-dev/Chef-New-Feature-Button-20ab57ff32ab80f286f6e38be16edbf3?d=20eb57ff32ab8059b7cb001c7dbfe293#20eb57ff32ab806b8fe7f00dc0c30887) doc. We now write `subchatIndex` and `lastSubchatIndex` in all relevant chats.

I updated tests and confirmed that things work in dev as expected. I had to also update the `shares` table to include a `subchatIndex` since it is at a point in time (added this in the design doc too).

I will run the migration to backfill all the new fields once these changes land in staging and then prod.