### PR TITLE
Skip writing new chatMessagesStorageState documents for message parts

### DIFF
--- a/convex/messages.test.ts
+++ b/convex/messages.test.ts
@@ -646,6 +646,9 @@ describe("messages", () => {
       expectedPartIndex: 0,
       expectedSubchatIndex: 0,
     });
+    const firstStorageState = await getChatStorageStates(t, chatId, sessionId);
+    // Should only have 2 states: initial chat record and the new message state
+    expect(firstStorageState.length).toBe(2);
 
     // Store update with same lastMessageRank but different content
     const updatedMessage: SerializedMessage = createMessage({
@@ -662,9 +665,9 @@ describe("messages", () => {
     });
 
     // Verify storage states
-    const storageStates = await getChatStorageStates(t, chatId, sessionId);
+    const finalStorageStates = await getChatStorageStates(t, chatId, sessionId);
     // Should only have 2 states: initial chat record and the updated message state
-    expect(storageStates.length).toBe(2);
+    expect(finalStorageStates.length).toBe(2);
 
     // Verify the updated state
     const updatedStorageInfo = await t.query(internal.messages.getInitialMessagesStorageInfo, {

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -276,6 +276,9 @@ export const updateStorageState = internalMutation({
     }
 
     if (previous.lastMessageRank === lastMessageRank) {
+      if (previous.partIndex >= partIndex) {
+        throw new Error("Tried to update to a part that is already stored. Should have already returned.");
+      }
       // This is a part update, so we can patch instead of inserting a new document, cleaning up the old stored state.
       // We do not support rewinding to parts.
       if (previous.storageId !== null) {


### PR DESCRIPTION
We currently write documents (and files) to `chatMessagesStorageState` on every message part update. We originally wanted to be able to rewind to message parts, but we never built that and I don't think we need to so we can stop writing all this extra data and patch the document instead, deleting the old snapshots as we go.