### PR TITLE
Save snapshotId on share in chatMessagesStorageState

### DIFF
--- a/convex/share.ts
+++ b/convex/share.ts
@@ -237,6 +237,7 @@ export const clone = mutation({
     await ctx.db.insert("chatMessagesStorageState", {
       chatId: clonedChatId,
       storageId: getShare.chatHistoryId,
+      snapshotId: getShare.snapshotId,
       lastMessageRank: getShare.lastMessageRank,
       subchatIndex: getShare.lastSubchatIndex,
       partIndex: getShare.partIndex ?? -1,

--- a/convex/snapshot.ts
+++ b/convex/snapshot.ts
@@ -38,6 +38,7 @@ export const getSnapshotUrl = query({
     }
 
     // Maintain backwards compatibility with older chats that don't have snapshots in the chatMessagesStorageState table
+    // Some chats might be in the chatMessagesStorageState table but still not have a snapshotId because of a bug in sharing.
 
     const snapshotId = chat?.snapshotId;
     if (!snapshotId) {


### PR DESCRIPTION
There's a bug where we haven't been saving the `snapshotId` in `chatMessagesStorageState` on share. It doesn't look like it impacts users because we will fall back to the `snapshotId` in the chats table, but it's definitely unexpected to have unset `snapshotId` in the `chatMessagesStorageState`.