### PR TITLE
send source query param when upgrading billing

### DIFF
--- a/app/components/chat/Chat.tsx
+++ b/app/components/chat/Chat.tsx
@@ -725,8 +725,8 @@ export function NoTokensText({ resetDisableChatMessage }: { resetDisableChatMess
         <Button
           href={
             selectedTeamSlug
-              ? `https://dashboard.convex.dev/t/${selectedTeamSlug}/settings/billing`
-              : 'https://dashboard.convex.dev/team/settings/billing'
+              ? `https://dashboard.convex.dev/t/${selectedTeamSlug}/settings/billing?source=chef`
+              : 'https://dashboard.convex.dev/team/settings/billing?source=chef'
           }
           className="w-fit"
           icon={<ExternalLinkIcon />}
@@ -787,13 +787,13 @@ export function DisabledText({
         <Button
           href={
             selectedTeamSlug
-              ? `https://dashboard.convex.dev/t/${selectedTeamSlug}/settings/billing`
-              : 'https://dashboard.convex.dev/team/settings/billing'
+              ? `https://dashboard.convex.dev/t/${selectedTeamSlug}/settings/billing?source=chef`
+              : 'https://dashboard.convex.dev/team/settings/billing?source=chef'
           }
           className="w-fit"
           icon={<ExternalLinkIcon />}
         >
-          {isPaidPlan ? 'Increase spending limit' : 'Upgrade to Pro'}
+          {isPaidPlan ? 'Increase spending limit' : 'Upgrade your plan'}
         </Button>
         {isPaidPlan && <span>or wait until limits reset</span>}
       </div>

--- a/app/components/chat/StreamingIndicator.tsx
+++ b/app/components/chat/StreamingIndicator.tsx
@@ -327,14 +327,14 @@ function LittleUsage({
               {isPaidPlan ? null : (
                 <li className="mt-2 border-t pt-2">
                   <Button
-                    href={`https://dashboard.convex.dev/t/${teamSlug}/settings/billing`}
+                    href={`https://dashboard.convex.dev/t/${teamSlug}/settings/billing?source=chef`}
                     target="_blank"
                     variant="unstyled"
                     className="underline hover:text-content-link"
                   >
-                    Upgrade to a paid plan
+                    Upgrade your plan
                   </Button>{' '}
-                  for 500K included Chef tokens every month.
+                  to get more tokens.
                 </li>
               )}
               {!isPaidPlan && (

--- a/app/components/settings/UsageCard.tsx
+++ b/app/components/settings/UsageCard.tsx
@@ -78,10 +78,10 @@ export function UsageCard() {
                 <h3>You&apos;ve used all the tokens included with your free plan.</h3>
                 <div className="flex flex-wrap items-center gap-2">
                   <Button
-                    href={`https://dashboard.convex.dev/t/${selectedTeamSlug}/settings/billing`}
+                    href={`https://dashboard.convex.dev/t/${selectedTeamSlug}/settings/billing?source=chef`}
                     icon={<ExternalLinkIcon />}
                   >
-                    Upgrade to a paid plan
+                    Upgrade your plan
                   </Button>
                   <span>or add your own API key below to send more messages.</span>
                 </div>


### PR DESCRIPTION
When the starter plus plan is available, the dashboard will respect the `source` query param to take you directly to the starter plus upgrade flow.