### PR TITLE
[Bugfix] Don't show recipes when not logged in

### DIFF
--- a/app/components/chat/MessageInput.tsx
+++ b/app/components/chat/MessageInput.tsx
@@ -272,52 +272,54 @@ export const MessageInput = memo(function MessageInput({
           {input.length > PROMPT_LENGTH_WARNING_THRESHOLD && <CharacterWarning />}
           <div className="ml-auto flex items-center gap-1">
             {chefAuthState.kind === 'unauthenticated' && <SignInButton />}
-            <MenuComponent
-              buttonProps={{
-                variant: 'neutral',
-                tip: 'Use a recipe',
-                inline: true,
-                icon: (
-                  <div className="text-lg">
-                    <SquaresPlusIcon className="size-4" />
+            {chefAuthState.kind === 'fullyLoggedIn' && (
+              <MenuComponent
+                buttonProps={{
+                  variant: 'neutral',
+                  tip: 'Use a recipe',
+                  inline: true,
+                  icon: (
+                    <div className="text-lg">
+                      <SquaresPlusIcon className="size-4" />
+                    </div>
+                  ),
+                }}
+                placement="top-start"
+              >
+                <div className="ml-3 flex items-center gap-1">
+                  <h2 className="text-sm font-bold">Use a recipe</h2>
+                  <Tooltip tip="Recipes are Chef prompts that add powerful full-stack features to your app." side="top">
+                    <span className="cursor-help text-content-tertiary">
+                      <InformationCircleIcon className="size-4" />
+                    </span>
+                  </Tooltip>
+                </div>
+                <MenuItemComponent action={() => insertTemplate('Make a collaborative text editor that ...')}>
+                  <div className="flex w-full items-center gap-2">
+                    <PencilSquareIcon className="size-4 text-content-secondary" />
+                    Make a collaborative text editor
                   </div>
-                ),
-              }}
-              placement="top-start"
-            >
-              <div className="ml-3 flex items-center gap-1">
-                <h2 className="text-sm font-bold">Use a recipe</h2>
-                <Tooltip tip="Recipes are Chef prompts that add powerful full-stack features to your app." side="top">
-                  <span className="cursor-help text-content-tertiary">
-                    <InformationCircleIcon className="size-4" />
-                  </span>
-                </Tooltip>
-              </div>
-              <MenuItemComponent action={() => insertTemplate('Make a collaborative text editor that ...')}>
-                <div className="flex w-full items-center gap-2">
-                  <PencilSquareIcon className="size-4 text-content-secondary" />
-                  Make a collaborative text editor
-                </div>
-              </MenuItemComponent>
-              <MenuItemComponent action={() => insertTemplate('Add AI chat to ...')}>
-                <div className="flex w-full items-center gap-2">
-                  <ChatBubbleLeftIcon className="size-4 text-content-secondary" />
-                  Add AI chat
-                </div>
-              </MenuItemComponent>
-              <MenuItemComponent action={() => insertTemplate('Add file upload to ...')}>
-                <div className="flex w-full items-center gap-2">
-                  <DocumentArrowUpIcon className="size-4 text-content-secondary" />
-                  Add file upload
-                </div>
-              </MenuItemComponent>
-              <MenuItemComponent action={() => insertTemplate('Add full text search to ...')}>
-                <div className="flex w-full items-center gap-2">
-                  <MagnifyingGlassIcon className="size-4 text-content-secondary" />
-                  Add full text search
-                </div>
-              </MenuItemComponent>
-            </MenuComponent>
+                </MenuItemComponent>
+                <MenuItemComponent action={() => insertTemplate('Add AI chat to ...')}>
+                  <div className="flex w-full items-center gap-2">
+                    <ChatBubbleLeftIcon className="size-4 text-content-secondary" />
+                    Add AI chat
+                  </div>
+                </MenuItemComponent>
+                <MenuItemComponent action={() => insertTemplate('Add file upload to ...')}>
+                  <div className="flex w-full items-center gap-2">
+                    <DocumentArrowUpIcon className="size-4 text-content-secondary" />
+                    Add file upload
+                  </div>
+                </MenuItemComponent>
+                <MenuItemComponent action={() => insertTemplate('Add full text search to ...')}>
+                  <div className="flex w-full items-center gap-2">
+                    <MagnifyingGlassIcon className="size-4 text-content-secondary" />
+                    Add full text search
+                  </div>
+                </MenuItemComponent>
+              </MenuComponent>
+            )}
             {chefAuthState.kind === 'fullyLoggedIn' && (
               <EnhancePromptButton
                 isEnhancing={isEnhancing}


### PR DESCRIPTION
Recipes aren't helpful when you aren't logged in because you can't send a message. This makes the behavior of this button consistent with the enhance prompt button.

Before:
![Screenshot 2025-06-17 at 4 07 31 PM](https://github.com/user-attachments/assets/72fcbd67-592b-4355-9f3e-5931e017224a)
After:
![Screenshot 2025-06-17 at 4 07 20 PM](https://github.com/user-attachments/assets/e2df76aa-cf1d-4d5d-937b-fb0d34e61729)
