### PR TITLE
Fix socialShare setting snapshotId to undefined

### DIFF
--- a/convex/share.ts
+++ b/convex/share.ts
@@ -119,7 +119,7 @@ export const getShareDescription = query({
   },
 });
 
-async function cloneShow(
+export async function cloneShow(
   ctx: MutationCtx,
   {
     showCode,
@@ -179,6 +179,7 @@ async function cloneShow(
     lastMessageRank: storageState.lastMessageRank,
     subchatIndex: storageState.subchatIndex,
     partIndex: storageState.partIndex,
+    snapshotId: storageState.snapshotId,
   });
 
   await startProvisionConvexProjectHelper(ctx, {

--- a/convex/socialShare.ts
+++ b/convex/socialShare.ts
@@ -46,6 +46,7 @@ export const share = mutation({
         allowShowInGallery,
         referralCode,
       });
+      return code;
     } else {
       await ctx.db.replace(existing._id, {
         ...existing,
@@ -54,6 +55,7 @@ export const share = mutation({
         allowShowInGallery,
         referralCode,
       });
+      return existing.code;
     }
   },
 });


### PR DESCRIPTION
We were setting the `snapshotId` to undefined when we cloned a social share. This fixes. The user impact of this bug was minimal - bad code state if you cloned and exited before the chat got saved.