### PR TITLE
Rewind threshold (30 messages) and migration to delete old chat storage states

### DIFF
--- a/convex/cleanup.test.ts
+++ b/convex/cleanup.test.ts
@@ -178,7 +178,7 @@ describe("deleteOldStorageStatesForLastMessageRank", () => {
     });
 
     // Run the cleanup function
-    await t.mutation(internal.cleanup.deleteOldStorageStatesForLastMessageRank, {
+    await t.mutation(internal.cleanup.deleteNonLatestStorageStatesForLastMessageRank, {
       chatId,
       lastMessageRank: 1,
       forReal: true,
@@ -273,12 +273,12 @@ describe("deleteOldStorageStatesForLastMessageRank", () => {
       });
     });
 
-    await t.mutation(internal.cleanup.deleteOldStorageStatesForLastMessageRank, {
+    await t.mutation(internal.cleanup.deleteNonLatestStorageStatesForLastMessageRank, {
       chatId,
       lastMessageRank: 1,
       forReal: true,
     });
-    await t.mutation(internal.cleanup.deleteOldStorageStatesForLastMessageRank, {
+    await t.mutation(internal.cleanup.deleteNonLatestStorageStatesForLastMessageRank, {
       chatId,
       lastMessageRank: 2,
       forReal: true,
@@ -334,7 +334,7 @@ describe("deleteOldStorageStatesForLastMessageRank", () => {
       return states;
     });
 
-    await t.mutation(internal.cleanup.deleteOldStorageStatesForLastMessageRank, {
+    await t.mutation(internal.cleanup.deleteNonLatestStorageStatesForLastMessageRank, {
       chatId,
       lastMessageRank: 1,
       forReal: true,
@@ -378,7 +378,7 @@ describe("deleteOldStorageStatesForLastMessageRank", () => {
     });
 
     // Run the cleanup function
-    await t.mutation(internal.cleanup.deleteOldStorageStatesForLastMessageRank, {
+    await t.mutation(internal.cleanup.deleteNonLatestStorageStatesForLastMessageRank, {
       chatId,
       lastMessageRank: 1,
       forReal: true,
@@ -427,7 +427,7 @@ describe("deleteOldStorageStatesForLastMessageRank", () => {
     });
 
     // Run the cleanup function with dry run
-    await t.mutation(internal.cleanup.deleteOldStorageStatesForLastMessageRank, {
+    await t.mutation(internal.cleanup.deleteNonLatestStorageStatesForLastMessageRank, {
       chatId,
       lastMessageRank: 1,
       forReal: false,

--- a/convex/cleanup.ts
+++ b/convex/cleanup.ts
@@ -56,7 +56,7 @@ export const deleteDebugFilesForInactiveChats = internalMutation({
 
 // Paginates over the chats table and schedules a function to delete all old storage states for each chat.
 // Schedules itself to keep iterating over chats table.
-export const deleteAllOldChatStorageStates = internalMutation({
+export const deleteAllNonLatestLastMessageRankStorageStates = internalMutation({
   args: {
     forReal: v.boolean(),
     cursor: v.optional(v.string()),
@@ -70,14 +70,14 @@ export const deleteAllOldChatStorageStates = internalMutation({
     });
     for (const chat of page) {
       console.log(`Scheduling cleanup for chat ${chat._id}`);
-      await ctx.scheduler.runAfter(0, internal.cleanup.deleteOldChatStorageStates, {
+      await ctx.scheduler.runAfter(0, internal.cleanup.deleteNonLatestLastMessageRankStorageStates, {
         chatId: chat._id,
         forReal,
         shouldScheduleNext,
       });
     }
     if (shouldScheduleNext && !isDone) {
-      await ctx.scheduler.runAfter(delayInMs, internal.cleanup.deleteAllOldChatStorageStates, {
+      await ctx.scheduler.runAfter(delayInMs, internal.cleanup.deleteAllNonLatestLastMessageRankStorageStates, {
         forReal,
         cursor: continueCursor,
         shouldScheduleNext,
@@ -87,8 +87,7 @@ export const deleteAllOldChatStorageStates = internalMutation({
 });
 
 // Paginate over chat storage states, scheduling deletion of old storage states for each lastMessageRank
-// TODO: Delete all storage states and files that are older than numRewindableMessages
-export const deleteOldChatStorageStates = internalMutation({
+export const deleteNonLatestLastMessageRankStorageStates = internalMutation({
   args: {
     chatId: v.id("chats"),
     forReal: v.boolean(),
@@ -120,7 +119,7 @@ export const deleteOldChatStorageStates = internalMutation({
       for (const [lastMessageRank, count] of lastMessageRankCounts) {
         if (count > 1) {
           console.log(`Scheduling cleanup for chat ${chatId} and lastMessageRank ${lastMessageRank}`);
-          await ctx.scheduler.runAfter(0, internal.cleanup.deleteOldStorageStatesForLastMessageRank, {
+          await ctx.scheduler.runAfter(0, internal.cleanup.deleteNonLatestStorageStatesForLastMessageRank, {
             chatId,
             lastMessageRank,
             forReal,
@@ -130,7 +129,7 @@ export const deleteOldChatStorageStates = internalMutation({
     }
 
     if (shouldScheduleNext && !isDone) {
-      await ctx.scheduler.runAfter(delayInMs, internal.cleanup.deleteOldChatStorageStates, {
+      await ctx.scheduler.runAfter(delayInMs, internal.cleanup.deleteNonLatestLastMessageRankStorageStates, {
         chatId,
         forReal,
         cursor: continueCursor,
@@ -141,7 +140,7 @@ export const deleteOldChatStorageStates = internalMutation({
 });
 
 // Delete all the storage states for non-latest parts of a lastMessageRank
-export const deleteOldStorageStatesForLastMessageRank = internalMutation({
+export const deleteNonLatestStorageStatesForLastMessageRank = internalMutation({
   args: {
     chatId: v.id("chats"),
     lastMessageRank: v.number(),

--- a/convex/messages.test.ts
+++ b/convex/messages.test.ts
@@ -8,7 +8,12 @@ import {
   verifyStoredMessages,
   type TestConvex,
 } from "./test.setup";
-import { getChatByIdOrUrlIdEnsuringAccess, type SerializedMessage, type StorageInfo } from "./messages";
+import {
+  getChatByIdOrUrlIdEnsuringAccess,
+  NUM_REWINDABLE_MESSAGES,
+  type SerializedMessage,
+  type StorageInfo,
+} from "./messages";
 import type { Id } from "./_generated/dataModel";
 
 function getChatStorageStates(t: TestConvex, chatId: string, sessionId: Id<"sessions">) {
@@ -659,6 +664,7 @@ describe("messages", () => {
       subchatIndex: 0,
       snapshotId: snapshotId1,
     });
+    await t.finishAllScheduledFunctions(() => vi.runAllTimers());
     await t.mutation(internal.messages.updateStorageState, {
       sessionId,
       chatId,
@@ -668,6 +674,7 @@ describe("messages", () => {
       subchatIndex: 0,
       snapshotId: snapshotId1,
     });
+    await t.finishAllScheduledFunctions(() => vi.runAllTimers());
     // This update SHOULD NOT delete `snapshotId1` because it is referenced by the previous storage state.
     await t.mutation(internal.messages.updateStorageState, {
       sessionId,
@@ -678,6 +685,7 @@ describe("messages", () => {
       subchatIndex: 0,
       snapshotId: snapshotId2,
     });
+    await t.finishAllScheduledFunctions(() => vi.runAllTimers());
     const snapshot1 = await t.run(async (ctx) => {
       return await ctx.storage.getUrl(snapshotId1);
     });
@@ -1104,5 +1112,115 @@ describe("eraseMessageHistory", () => {
         dryRun: false,
       }),
     ).rejects.toThrow("No filesystem snapshot found for chat");
+  });
+});
+
+async function createStorageStates(t: TestConvex, chatId: string, sessionId: Id<"sessions">, numStates: number) {
+  const storageStates: Array<{ rank: number; storageId: Id<"_storage">; snapshotId: Id<"_storage"> }> = [];
+  for (let i = 0; i < numStates; i++) {
+    const storageId = await t.run(async (ctx) => {
+      return await ctx.storage.store(new Blob([`storage content ${i}`]));
+    });
+    const snapshotId = await t.run(async (ctx) => {
+      return await ctx.storage.store(new Blob([`snapshot content ${i}`]));
+    });
+
+    await t.mutation(internal.messages.updateStorageState, {
+      sessionId,
+      chatId,
+      snapshotId,
+      storageId,
+      lastMessageRank: i,
+      subchatIndex: 0,
+      partIndex: 0,
+    });
+    await t.finishAllScheduledFunctions(() => vi.runAllTimers());
+    storageStates.push({ rank: i, storageId, snapshotId });
+  }
+  return storageStates;
+}
+
+describe("deleteStorageStatesPastRewindThreshold", () => {
+  let t: TestConvex;
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    t = setupTest();
+  });
+
+  afterEach(async () => {
+    await t.finishAllScheduledFunctions(() => vi.runAllTimers());
+    vi.useRealTimers();
+  });
+
+  test("deletes storage states past NUM_REWINDABLE_MESSAGES threshold", async () => {
+    const { sessionId, chatId } = await createChat(t);
+
+    // Create many storage states with different lastMessageRank values
+    // We'll create 30 storage states (0-29) to test the threshold
+    const storageStates = await createStorageStates(t, chatId, sessionId, 10 + NUM_REWINDABLE_MESSAGES);
+
+    // Verify that storage states with lastMessageRank <= (29 - 20) = 9 are deleted
+    // So ranks 0-9 should be deleted, ranks 10-29 should remain
+    const finalStorageStates = await getChatStorageStates(t, chatId, sessionId);
+
+    // Should have 20 remaining storage states (ranks 10-29)
+    expect(finalStorageStates.length).toBe(NUM_REWINDABLE_MESSAGES);
+
+    // Verify the remaining storage states are the correct ones
+    const remainingRanks = finalStorageStates
+      .filter((state) => state.lastMessageRank !== -1) // Exclude the initial chat record
+      .map((state) => state.lastMessageRank)
+      .sort((a, b) => a - b);
+
+    expect(remainingRanks).toEqual(Array.from({ length: NUM_REWINDABLE_MESSAGES }, (_, i) => i + 10));
+
+    // Verify that the storage blobs for deleted states are also deleted
+    await t.run(async (ctx) => {
+      // Check that storage blobs for ranks 0-9 are deleted
+      for (let i = 0; i < 10; i++) {
+        const storageBlob = await ctx.storage.get(storageStates[i].storageId);
+        expect(storageBlob).toBeNull();
+        const snapshotBlob = await ctx.storage.get(storageStates[i].snapshotId);
+        expect(snapshotBlob).toBeNull();
+      }
+
+      // Check that storage blobs for ranks 10-29 are still present
+      for (let i = 10; i < 30; i++) {
+        const storageBlob = await ctx.storage.get(storageStates[i].storageId);
+        expect(storageBlob).not.toBeNull();
+        const snapshotBlob = await ctx.storage.get(storageStates[i].snapshotId);
+        expect(snapshotBlob).not.toBeNull();
+      }
+    });
+  });
+
+  test("does not delete storage states when below threshold", async () => {
+    const { sessionId, chatId } = await createChat(t);
+
+    // Create only 10 storage states (0-9), which is below the threshold of 20
+    const storageStates = await createStorageStates(t, chatId, sessionId, 10);
+
+    // Call the function to delete old storage states
+    await t.mutation(internal.messages.deleteStorageStatesPastRewindThreshold, {
+      chatId: await t.run(async (ctx) => {
+        const chat = await getChatByIdOrUrlIdEnsuringAccess(ctx, { id: chatId, sessionId });
+        return chat!._id;
+      }),
+      subchatIndex: 0,
+    });
+
+    // Verify that no storage states are deleted since we're below the threshold
+    const finalStorageStates = await getChatStorageStates(t, chatId, sessionId);
+    expect(finalStorageStates.length).toBe(11); // Should still have all 10 + 1 for the initial chat record
+
+    // Verify all storage blobs are still present
+    await t.run(async (ctx) => {
+      for (let i = 0; i < 10; i++) {
+        const storageBlob = await ctx.storage.get(storageStates[i].storageId);
+        expect(storageBlob).not.toBeNull();
+        const snapshotBlob = await ctx.storage.get(storageStates[i].snapshotId);
+        expect(snapshotBlob).not.toBeNull();
+      }
+    });
   });
 });

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -16,6 +16,10 @@ import { ensureEnvVar, startProvisionConvexProjectHelper } from "./convexProject
 import { internal } from "./_generated/api";
 import { assertIsConvexAdmin } from "./admin";
 
+export const NUM_REWINDABLE_MESSAGES = process.env.NUM_REWINDABLE_MESSAGES
+  ? parseInt(process.env.NUM_REWINDABLE_MESSAGES)
+  : 30;
+
 export type SerializedMessage = Omit<AIMessage, "createdAt" | "content"> & {
   createdAt: number | undefined;
   content?: string;
@@ -229,6 +233,47 @@ export const getMessagesByChatInitialIdBypassingAccessControl = internalQuery({
   },
 });
 
+export async function deleteOldChatStorageStatesForChat(ctx: MutationCtx, chatId: Id<"chats">, subchatIndex: number) {
+  const latestStorageState = await ctx.db
+    .query("chatMessagesStorageState")
+    .withIndex("byChatId", (q) => q.eq("chatId", chatId).eq("subchatIndex", subchatIndex))
+    .order("desc")
+    .first();
+  if (!latestStorageState) {
+    return;
+  }
+  // Delete all the storage states that are unreferenced and past the rewind threshold
+  const storageStatesToDelete = await ctx.db
+    .query("chatMessagesStorageState")
+    .withIndex("byChatId", (q) =>
+      q
+        .eq("chatId", chatId)
+        .eq("subchatIndex", subchatIndex)
+        .lte("lastMessageRank", latestStorageState.lastMessageRank - NUM_REWINDABLE_MESSAGES),
+    )
+    .collect();
+  for (const storageState of storageStatesToDelete) {
+    await ctx.db.delete(storageState._id);
+    // Delete files if unused
+    if (storageState.storageId) {
+      await deleteChatStorageIdIfUnused(ctx, storageState.storageId);
+    }
+    if (storageState.snapshotId) {
+      await deleteSnapshotIdIfUnused(ctx, storageState.snapshotId);
+    }
+  }
+}
+
+export const deleteStorageStatesPastRewindThreshold = internalMutation({
+  args: {
+    chatId: v.id("chats"),
+    subchatIndex: v.number(),
+  },
+  handler: async (ctx, { chatId, subchatIndex }) => {
+    await deleteOldChatStorageStatesForChat(ctx, chatId, subchatIndex);
+  },
+});
+
 export const updateStorageState = internalMutation({
   args: {
     sessionId: v.id("sessions"),
@@ -246,7 +291,7 @@ export const updateStorageState = internalMutation({
     if (!chat) {
       throw CHAT_NOT_FOUND_ERROR;
     }
-    await deletePreviousStorageStates(ctx, { chat, subchatIndex: args.subchatIndex });
+    await deleteFutureStorageStatesIfRewind(ctx, { chat, subchatIndex: args.subchatIndex });
     const previous = await getLatestChatMessageStorageState(ctx, {
       _id: chat._id,
       subchatIndex: args.subchatIndex,
@@ -288,6 +333,10 @@ export const updateStorageState = internalMutation({
       throw new Error("Received null storageId for a chat with messages");
     }
 
+    ctx.scheduler.runAfter(0, internal.messages.deleteStorageStatesPastRewindThreshold, {
+      chatId: chat._id,
+      subchatIndex: args.subchatIndex,
+    });
     if (previous.lastMessageRank === lastMessageRank) {
       if (previous.partIndex >= partIndex) {
         throw new Error("Tried to update to a part that is already stored. Should have already returned.");
@@ -343,7 +392,7 @@ export async function storageIdUnusedByShares(ctx: MutationCtx, chatStorageId: I
   return shareRef === null;
 }
 
-async function deleteChatStorageIdIfUnused(ctx: MutationCtx, chatStorageId: Id<"_storage">) {
+export async function deleteChatStorageIdIfUnused(ctx: MutationCtx, chatStorageId: Id<"_storage">) {
   const chatHistoryRef = await ctx.db
     .query("chatMessagesStorageState")
     .withIndex("byStorageId", (q) => q.eq("storageId", chatStorageId))
@@ -372,7 +421,7 @@ export async function snapshotIdUnusedByChatsAndShares(ctx: MutationCtx, snapsho
   return chatRef === null && shareRef === null;
 }
 
-async function deleteSnapshotIdIfUnused(ctx: MutationCtx, snapshotId: Id<"_storage">) {
+export async function deleteSnapshotIdIfUnused(ctx: MutationCtx, snapshotId: Id<"_storage">) {
   const chatHistoryRef = await ctx.db
     .query("chatMessagesStorageState")
     .withIndex("bySnapshotId", (q) => q.eq("snapshotId", snapshotId))
@@ -395,7 +444,7 @@ async function deleteStorageState(ctx: MutationCtx, storageState: Doc<"chatMessa
   }
 }
 
-async function deletePreviousStorageStates(
+async function deleteFutureStorageStatesIfRewind(
   ctx: MutationCtx,
   args: {
     chat: Doc<"chats">;

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -1,5 +1,6 @@
 import { Migrations } from "@convex-dev/migrations";
 import { components, internal } from "./_generated/api.js";
+import { deleteOldChatStorageStatesForChat } from "./messages.js";
 
 export const migrations = new Migrations(components.migrations);
 export const run = migrations.runner();
@@ -60,3 +61,12 @@ export const addSubchatIndexToDebugChatApiRequestLog = migrations.define({
 export const runAddSubchatIndexToDebugChatApiRequestLog = migrations.runner(
   internal.migrations.addSubchatIndexToDebugChatApiRequestLog,
 );
+
+export const deleteOldChatStorageStates = migrations.define({
+  table: "chats",
+  migrateOne: async (ctx, doc) => {
+    await deleteOldChatStorageStatesForChat(ctx, doc._id, 0);
+  },
+});
+
+export const runDeleteOldChatStorageStates = migrations.runner(internal.migrations.deleteOldChatStorageStates);

--- a/convex/test.setup.ts
+++ b/convex/test.setup.ts
@@ -4,7 +4,7 @@ import { api } from "./_generated/api";
 import type { SerializedMessage } from "./messages";
 import type { Id } from "./_generated/dataModel";
 import type { GenericMutationCtx } from "convex/server";
-import { expect } from "vitest";
+import { expect, vi } from "vitest";
 
 // TODO -- for some reason, parameterizing on the generated `DataModel` does not work
 export type TestConvex = TestConvexForDataModel<any>;
@@ -83,6 +83,8 @@ export async function storeChat(
       throw new Error(`Failed to store chat: ${response.statusText}`);
     }
   }
+  vi.useFakeTimers();
+  await t.finishAllScheduledFunctions(() => vi.runAllTimers());
   return response;
 }
 


### PR DESCRIPTION
This PR adds a migration to delete `chatMessagesStorageState` documents and unreferenced files that are more than 30 messages before the latest message and schedules a mutation to do the same in `updateStorageState`. Now that we've cleaned up all the non-latest duplicate documents for `lastMessageRank` parts, I'm not worried about hitting transaction limits. The deletion logic is in `deleteOldChatStorageStatesForChat`, and we call this fn from the migration and schedule it in `updateStorageState`.

