### PR TITLE
Fix toolcall loops by not filtering out toolcall result messages

### DIFF
--- a/chef-agent/cleanupAssistantMessages.ts
+++ b/chef-agent/cleanupAssistantMessages.ts
@@ -21,7 +21,8 @@ export function cleanupAssistantMessages(messages: Message[]) {
   processedMessages = processedMessages.filter(
     (message) =>
       message.content.trim() !== '' ||
-      (message.parts && message.parts.filter((part) => part.type === 'text').length > 0),
+      (message.parts &&
+        message.parts.filter((part) => part.type === 'text' || part.type === 'tool-invocation').length > 0),
   );
   return convertToCoreMessages(processedMessages).filter((message) => message.content.length > 0);
 }


### PR DESCRIPTION
I'd frequently see the edit or view toolcall get called in a loop, and from the debug prompt view, I could see that the toolcall messages weren't getting sent back up. I think the toolcall results were getting filtered out as empty messages. This fixes by keeping all tool-invocation messages.