### PR TITLE
Merging staging into release

### DIFF
--- a/app/components/chat/Chat.tsx
+++ b/app/components/chat/Chat.tsx
@@ -103,7 +103,7 @@ export const Chat = memo(
         if (!chatId) {
           return;
         }
-        if (!subchatIndex) {
+        if (subchatIndex === undefined) {
           return;
         }
 


### PR DESCRIPTION
`!0` evaluates to true and all users are currently on the `0th` subchat, so they aren't able to rewind. We now explicitly check for undefined.

I tested that this works locally.

<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
