### PR TITLE
Add better empty state for subchats

### DIFF
--- a/app/components/chat/Messages.client.tsx
+++ b/app/components/chat/Messages.client.tsx
@@ -148,7 +148,7 @@ export const Messages = forwardRef<HTMLDivElement, MessagesProps>(function Messa
           );
         })
       ) : (
-        <div className="flex flex-col items-center justify-center py-16 px-4 text-center">
+        <div className="flex flex-col items-center justify-center px-4 py-16 text-center">
           <div className="mb-6 flex size-[64px] shrink-0 items-center justify-center rounded-full bg-white text-gray-600 dark:bg-gray-800 dark:text-gray-500">
             <ChatBubbleIcon className="size-8" />
           </div>


### PR DESCRIPTION
Makes the new chat state feel less empty. Suggestion from @atrakh 
<img width="1624" alt="Screenshot 2025-06-30 at 10 17 05 AM" src="https://github.com/user-attachments/assets/cfbd7d96-fbee-47f6-b558-2f6aef5fcceb" />
