### PR TITLE
[New Chat] Bug fixes

### DIFF
--- a/app/lib/stores/startup/useInitialMessages.ts
+++ b/app/lib/stores/startup/useInitialMessages.ts
@@ -59,8 +59,6 @@ export function useInitialMessages(chatId: string | undefined):
           setInitialMessages(undefined);
           return;
         }
-
-        // Only initialize subchatIndex once per chat
         if (subchatIndex === undefined) {
           subchatLoadedStore.set(false);
           subchatIndexStore.set(chatInfo.subchatIndex);

--- a/convex/snapshot.ts
+++ b/convex/snapshot.ts
@@ -25,14 +25,13 @@ export const getSnapshotUrl = query({
   args: {
     sessionId: v.id("sessions"),
     chatId: v.string(),
-    subchatIndex: v.optional(v.number()),
   },
-  handler: async (ctx, { sessionId, chatId, subchatIndex }) => {
+  handler: async (ctx, { sessionId, chatId }) => {
     const chat = await getChatByIdOrUrlIdEnsuringAccess(ctx, { id: chatId, sessionId });
     if (!chat) {
       throw new Error("Chat not found");
     }
-    const chatWithSubchatIndex = { ...chat, subchatIndex: subchatIndex ?? 0 };
+    const chatWithSubchatIndex = { ...chat, subchatIndex: chat.lastSubchatIndex };
     const latestChatStorageState = await getLatestChatMessageStorageState(ctx, chatWithSubchatIndex);
     if (latestChatStorageState?.snapshotId) {
       const url = await ctx.storage.getUrl(latestChatStorageState.snapshotId);


### PR DESCRIPTION
Fixes two separate bugs:
- we would call `initial_messages` twice on the initial render because we would change the `subchatIndex`. we have to `return` after we change it so we don't execute the api call twice in a row
- read the `snapshot` from the latest subchat instead of the first one, this was causing us to always show the file system snapshot from the first chat