### PR TITLE
[New Chat] Fix rewind UI

### DIFF
--- a/app/components/chat/SubchatBar.tsx
+++ b/app/components/chat/SubchatBar.tsx
@@ -182,7 +182,7 @@ export function SubchatBar({
         </div>
 
         <div className="flex items-center gap-2">
-          {currentSubchatIndex === (subchats?.length ?? 1) - 1 && sessionId ? (
+          {currentSubchatIndex >= (subchats?.length ?? 1) - 1 && sessionId ? (
             <Button
               size="xs"
               variant="neutral"


### PR DESCRIPTION
The rewind button used to show up on the new chat when you created it b/c we do an optimistic update. This fix makes it so that we correctly show the `+` button when we create the chat.