### PR TITLE
[New Chat] + button fix

### DIFF
--- a/app/lib/stores/startup/useInitialMessages.ts
+++ b/app/lib/stores/startup/useInitialMessages.ts
@@ -28,6 +28,7 @@ export function useInitialMessages(chatId: string | undefined):
   const [initialMessages, setInitialMessages] = useState<InitialMessages | null | undefined>();
   const sessionIdOrNullOrLoading = useConvexSessionIdOrNullOrLoading();
   const subchatIndex = useStore(subchatIndexStore);
+  const subchatLoaded = useStore(subchatLoadedStore);
   const subchats = useQuery(
     api.subchats.get,
     sessionIdOrNullOrLoading && chatId
@@ -62,6 +63,8 @@ export function useInitialMessages(chatId: string | undefined):
         if (subchatIndex === undefined) {
           subchatLoadedStore.set(false);
           subchatIndexStore.set(chatInfo.subchatIndex);
+          // Clear existing messages to prevent showing old messages during subchat switch
+          setInitialMessages(undefined);
           // Exit early to let the effect run again with the new subchatIndex
           return;
         }


### PR DESCRIPTION
When adding a new chat, sometimes the messages from the previous chat would show up. This fixes the bug by setting the messages to `undefined` while we are loading a new set of messages.