### PR TITLE
[New Chat] Fix saving after creating a new subchat

### DIFF
--- a/app/lib/stores/startup/history.ts
+++ b/app/lib/stores/startup/history.ts
@@ -157,6 +157,7 @@ async function chatSyncWorker(args: {
   chatSyncState.set({
     ...currentState,
     started: true,
+    savedFileUpdateCounter: currentState.savedFileUpdateCounter ?? getFileUpdateCounter(),
   });
   while (true) {
     const currentState = await waitForInitialized();


### PR DESCRIPTION
When creating a new subchat, the messages wouldn't save properly because we didn't correctly initialize `savedFileUpdateCounter`. This change sets the value and I tested that the saving behavior now works properly.