### PR TITLE
Add toolcall for getting deployment name

### DIFF
--- a/app/components/chat/ToolCall.tsx
+++ b/app/components/chat/ToolCall.tsx
@@ -91,7 +91,7 @@ export const ToolCall = memo(function ToolCall({ partId, toolCallId }: { partId:
         </button>
         <div className="w-px bg-bolt-elements-artifacts-borderColor" />
         <AnimatePresence>
-          {artifact.type !== 'bundled' && (
+          {artifact.type !== 'bundled' && parsed.toolName !== 'getConvexDeploymentName' && (
             <motion.button
               initial={{ width: 0 }}
               animate={{ width: 'auto' }}
@@ -160,6 +160,9 @@ const ToolUseContents = memo(function ToolUseContents({
     }
     case 'addEnvironmentVariables': {
       return <AddEnvironmentVariablesTool invocation={invocation} />;
+    }
+    case 'getConvexDeploymentName': {
+      return <GetConvexDeploymentNameTool invocation={invocation} />;
     }
     default: {
       // Fallback for other tool types
@@ -486,6 +489,20 @@ function toolTitle(invocation: ConvexToolInvocation): React.ReactNode {
         </div>
       );
     }
+    case 'getConvexDeploymentName': {
+      if (invocation.state === 'partial-call' || invocation.state === 'call') {
+        return 'Getting Convex deployment name...';
+      } else if (invocation.result?.startsWith('Error:')) {
+        return 'Failed to get Convex deployment name';
+      } else {
+        return (
+          <div className="flex items-center gap-2">
+            <img className="mr-1 size-4" height="16" width="16" src="/icons/Convex.svg" alt="Convex" />
+            <span>Got Convex deployment name: {invocation.result}</span>
+          </div>
+        );
+      }
+    }
     default: {
       return (invocation as any).toolName;
     }
@@ -707,6 +724,33 @@ function AddEnvironmentVariablesTool({ invocation }: { invocation: ConvexToolInv
             <li key={name}>{name}</li>
           ))}
         </ul>
+      </div>
+    </div>
+  );
+}
+
+function GetConvexDeploymentNameTool({ invocation }: { invocation: ConvexToolInvocation }) {
+  if (invocation.toolName !== 'getConvexDeploymentName') {
+    throw new Error('GetConvexDeploymentNameTool can only be used for the getConvexDeploymentName tool');
+  }
+  if (invocation.state === 'partial-call' || invocation.state === 'call') {
+    return null;
+  }
+  if (invocation.result.startsWith('Error:')) {
+    return (
+      <div className="overflow-hidden rounded-lg border bg-bolt-elements-background-depth-1 font-mono text-sm text-content-primary">
+        <pre>{invocation.result}</pre>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border bg-bolt-elements-background-depth-1 font-mono text-sm text-content-primary">
+      <div className="space-y-2 p-4">
+        <div className="flex items-center gap-2">
+          <span>Convex Deployment Name:</span>
+          <code className="rounded bg-bolt-elements-background-depth-2 px-2 py-1 font-mono">{invocation.result}</code>
+        </div>
       </div>
     </div>
   );

--- a/app/lib/.server/llm/convex-agent.ts
+++ b/app/lib/.server/llm/convex-agent.ts
@@ -34,6 +34,7 @@ import { getEnv } from '~/lib/.server/env';
 import { calculateChefTokens, usageFromGeneration } from '~/lib/common/usage';
 import { lookupDocsTool } from 'chef-agent/tools/lookupDocs';
 import { addEnvironmentVariablesTool } from 'chef-agent/tools/addEnvironmentVariables';
+import { getConvexDeploymentNameTool } from 'chef-agent/tools/getConvexDeploymentName';
 
 type Messages = Message[];
 
@@ -95,6 +96,7 @@ export async function convexAgent(args: {
     deploy: deployTool,
     npmInstall: npmInstallTool,
     lookupDocs: lookupDocsTool(),
+    getConvexDeploymentName: getConvexDeploymentNameTool,
   };
   if (featureFlags.enableEnvironmentVariables) {
     tools.addEnvironmentVariables = addEnvironmentVariablesTool();

--- a/app/lib/common/types.ts
+++ b/app/lib/common/types.ts
@@ -6,6 +6,7 @@ import type { viewParameters } from 'chef-agent/tools/view';
 import type { ActionStatus } from '~/lib/runtime/action-runner';
 import type { lookupDocsParameters } from 'chef-agent/tools/lookupDocs';
 import type { ConvexToolSet, EmptyArgs } from 'chef-agent/types';
+import type { getConvexDeploymentNameParameters } from 'chef-agent/tools/getConvexDeploymentName';
 
 type ConvexToolCall = ToolCallUnion<ConvexToolSet>;
 
@@ -40,6 +41,11 @@ type ConvexToolResult =
   | {
       toolName: 'addEnvironmentVariables';
       args: typeof addEnvironmentVariablesParameters;
+      result: string;
+    }
+  | {
+      toolName: 'getConvexDeploymentName';
+      args: typeof getConvexDeploymentNameParameters;
       result: string;
     };
 

--- a/app/lib/runtime/action-runner.ts
+++ b/app/lib/runtime/action-runner.ts
@@ -25,6 +25,7 @@ import type { ConvexToolName } from '~/lib/common/types';
 import { lookupDocsParameters, docs, type DocKey } from 'chef-agent/tools/lookupDocs';
 import { addEnvironmentVariablesParameters } from 'chef-agent/tools/addEnvironmentVariables';
 import { openDashboardToPath } from '~/lib/stores/dashboardPath';
+import { convexProjectStore } from '~/lib/stores/convexProject';
 
 const logger = createScopedLogger('ActionRunner');
 
@@ -518,6 +519,16 @@ export class ActionRunner {
           }
           openDashboardToPath(path);
           result = `Opened dashboard to add environment variables: ${envVarNames.join(', ')}\nPlease add the values in the dashboard.`;
+          break;
+        }
+        case 'getConvexDeploymentName': {
+          const convexProject = convexProjectStore.get();
+          if (!convexProject) {
+            result = 'Error: No Convex project is currently connected. Please connect a Convex project first.';
+          } else {
+            result = convexProject.deploymentName;
+            console.log('getConvexDeploymentName tool called, returning:', result);
+          }
           break;
         }
         default: {

--- a/chef-agent/ChatContextManager.ts
+++ b/chef-agent/ChatContextManager.ts
@@ -392,6 +392,10 @@ function abbreviateToolInvocation(toolInvocation: ToolInvocation): string {
       }
       break;
     }
+    case 'getConvexDeploymentName': {
+      toolCall = `retrieved the Convex deployment name`;
+      break;
+    }
     default:
       throw new Error(`Unknown tool name: ${toolInvocation.toolName}`);
   }

--- a/chef-agent/tools/getConvexDeploymentName.ts
+++ b/chef-agent/tools/getConvexDeploymentName.ts
@@ -1,0 +1,17 @@
+import type { Tool } from 'ai';
+import { z } from 'zod';
+
+export const getConvexDeploymentNameDescription = `
+Get the name of the Convex deployment this project is using. This tool returns the deployment name that is used
+to identify in the dashboard and for deployment operations.
+
+The deployment name is a unique identifier and can be used to access the Convex dashboard:
+https://dashboard.convex.dev/d/{deploymentName}.
+`;
+
+export const getConvexDeploymentNameParameters = z.object({});
+
+export const getConvexDeploymentNameTool: Tool = {
+  description: getConvexDeploymentNameDescription,
+  parameters: getConvexDeploymentNameParameters,
+};

--- a/chef-agent/types.ts
+++ b/chef-agent/types.ts
@@ -7,6 +7,7 @@ import type { viewParameters } from './tools/view.js';
 import type { lookupDocsParameters } from './tools/lookupDocs.js';
 import type { z } from 'zod';
 import type { addEnvironmentVariablesParameters } from './tools/addEnvironmentVariables.js';
+import type { getConvexDeploymentNameParameters } from './tools/getConvexDeploymentName.js';
 
 export type ConvexProject = {
   token: string;
@@ -85,6 +86,7 @@ export type ConvexToolSet = {
   addEnvironmentVariables?: Tool<typeof addEnvironmentVariablesParameters, void>;
   view?: Tool<typeof viewParameters, string>;
   edit?: Tool<typeof editToolParameters, string>;
+  getConvexDeploymentName: Tool<typeof getConvexDeploymentNameParameters, string>;
 };
 
 export type Dirent = File | Folder;

--- a/test-kitchen/chefTask.ts
+++ b/test-kitchen/chefTask.ts
@@ -16,6 +16,7 @@ import { generateId } from 'ai';
 import { ConvexToolSet, SystemPromptOptions } from 'chef-agent/types';
 import { npmInstallTool, npmInstallToolParameters } from 'chef-agent/tools/npmInstall';
 import { lookupDocsTool } from 'chef-agent/tools/lookupDocs';
+import { getConvexDeploymentNameTool } from 'chef-agent/tools/getConvexDeploymentName';
 import { cleanupAssistantMessages } from 'chef-agent/cleanupAssistantMessages';
 import { generalSystemPrompt } from 'chef-agent/prompts/system';
 import { makePartId } from 'chef-agent/partId';
@@ -284,6 +285,10 @@ export async function chefTask(model: ChefModel, outputDir: string, userMessage:
               toolCallResult = await npmInstall(repoDir, packages);
               break;
             }
+            case 'getConvexDeploymentName': {
+              toolCallResult = backend.project.deploymentName;
+              break;
+            }
             default:
               throw new Error(`Unknown tool call: ${JSON.stringify(toolCall)}`);
           }
@@ -402,6 +407,7 @@ async function invokeGenerateText(model: ChefModel, opts: SystemPromptOptions, c
           deploy: deployTool,
           npmInstall: npmInstallTool,
           lookupDocs: lookupDocsTool(),
+          getConvexDeploymentName: getConvexDeploymentNameTool,
         };
         if (opts.enablePreciseEdits) {
           tools.view = viewTool;


### PR DESCRIPTION
This is useful for components users will need to set up webhooks for. We can have the agent print a string for the convex url that should just work.