### PR TITLE
Show header on initial chat

### DIFF
--- a/app/components/chat/Chat.tsx
+++ b/app/components/chat/Chat.tsx
@@ -433,8 +433,8 @@ export const Chat = memo(
     setChefDebugProperty('parsedMessages', parsedMessages);
 
     useEffect(() => {
-      chatStore.setKey('started', initialMessages.length > 0 || (!!subchats && subchats.length > 1));
-    }, [initialMessages.length, subchats]);
+      chatStore.setKey('started', messages.length > 0 || (!!subchats && subchats.length > 1));
+    }, [messages.length, subchats]);
 
     useEffect(() => {
       processSampledMessages({


### PR DESCRIPTION
Previously, this would only show up when `initialMessages` was updated, not the local state, which is what we care about.