### PR TITLE
Simplify point-in-time shares UI

### DIFF
--- a/app/components/header/ShareButton.tsx
+++ b/app/components/header/ShareButton.tsx
@@ -34,7 +34,6 @@ export function ShareButton() {
   const [isThumbnailModalOpen, setIsThumbnailModalOpen] = useState(false);
   const [snapshotStatus, setSnapshotStatus] = useState<SnapshotStatus>('idle');
   const [shareStatus, setShareStatus] = useState<ShareStatus>('idle');
-  const [snapshotCode, setSnapshotCode] = useState<string | null>(null);
   const [snapshotUrl, setSnapshotUrl] = useState('');
   const [shareUrl, setShareUrl] = useState('');
 


### PR DESCRIPTION
Combines all of the point-in-time share UI logic into a single place. There was a weird race condition that was happening when we had the loading state updated in a separate `useEffect` that caused the wrong code to show up.