### PR TITLE
[Bugfix] Save current preference properly

### DIFF
--- a/app/components/chat/MissingApiKey.tsx
+++ b/app/components/chat/MissingApiKey.tsx
@@ -34,7 +34,7 @@ export function MissingApiKey({ provider, requireKey, resetDisableChatMessage }:
       const apiKey = await convex.query(api.apiKeys.apiKeyForCurrentMember);
 
       const apiKeyMutation: Doc<'convexMembers'>['apiKey'] = {
-        preference: apiKey?.preference || ('always' as 'always' | 'quotaExhausted'),
+        preference: apiKey?.preference || ('quotaExhausted' as 'always' | 'quotaExhausted'),
         value: apiKey?.value || undefined,
         openai: apiKey?.openai || undefined,
         xai: apiKey?.xai || undefined,

--- a/app/components/settings/ApiKeyCard.tsx
+++ b/app/components/settings/ApiKeyCard.tsx
@@ -260,7 +260,7 @@ function ApiKeyItem({
       const apiKey = await convex.query(api.apiKeys.apiKeyForCurrentMember);
 
       const apiKeyMutation = {
-        preference: 'quotaExhausted' as 'always' | 'quotaExhausted',
+        preference: apiKey?.preference || ('quotaExhausted' as 'always' | 'quotaExhausted'),
         value: apiKey?.value || undefined,
         openai: apiKey?.openai || undefined,
         xai: apiKey?.xai || undefined,


### PR DESCRIPTION
Previously, when changing api keys, it would always uncheck the "Always use my API keys" box. Now, we send up the current preference instead and default to `quotaExhausted`. This fixes an issue reported by a customer.