### PR TITLE
[Resend] Update the resend component

### DIFF
--- a/app/lib/.server/llm/convex-agent.ts
+++ b/app/lib/.server/llm/convex-agent.ts
@@ -90,7 +90,7 @@ export async function convexAgent(args: {
     openaiProxyEnabled: getEnv('OPENAI_PROXY_ENABLED') == '1',
     usingOpenAi: modelProvider == 'OpenAI',
     usingGoogle: modelProvider == 'Google',
-    resendProxyEnabled: getEnv('RESEND_PROXY_ENABLED') == '1',
+    resendProxyEnabled: !featureFlags.enableResend && getEnv('RESEND_PROXY_ENABLED') == '1',
     smallFiles: featureFlags.smallFiles,
     enableResend: featureFlags.enableResend,
   };

--- a/chef-agent/prompts/components/resend.ts
+++ b/chef-agent/prompts/components/resend.ts
@@ -44,7 +44,7 @@ import { components } from "./_generated/api";
 import { Resend } from "@convex-dev/resend";
 import { internalMutation } from "./_generated/server";
 
-export const resend: Resend = new Resend(components.resend, { testMode: false});
+export const resend: Resend = new Resend(components.resend, { testMode: false });
 
 export const sendEmail = internalMutation({
   handler: async (ctx) => {
@@ -60,7 +60,7 @@ export const sendEmail = internalMutation({
 \`\`\`
 
 Then, calling \`sendEmail\` from anywhere in your app will send this email. 
-You should use the onboarding@resend.dev email address to send emails unless the user requests otherwise.
+You should alwaysuse the onboarding@resend.dev email address as the from email unless the user requests otherwise.
 
 ## Advanced: Setting up a webhook
 Only do this if the user specifically asks for it. This will allow you to get email status updates.
@@ -104,7 +104,7 @@ batches!
 
 Speaking of...
 
-### Registering an email status event handler. Only do this if the user asks for it.
+### Registering an email status event handler.
 
 If you have your webhook established, you can also register an event handler in your
 apps you get notifications when email statuses change.

--- a/chef-agent/prompts/convexGuidelines.ts
+++ b/chef-agent/prompts/convexGuidelines.ts
@@ -950,4 +950,4 @@ Chef does not have documentation for them. Tell the user that they are unsupport
 `;
 }
 
-const resendComponent = `- \`resend\`: A component for sending emails.`;
+const resendComponent = `- \`resend\`: A component for sending emails. This is the recommended way to send emails.`;


### PR DESCRIPTION
Cleans up the resend component docs by:
- removing unnecessary info
- pass in an example with test mode off, which actually sends emails
- remove the `RESEND_DOMAIN` from setup
- remove the webhook env variable from the default setup