### PR TITLE
[Bugfix] Paginate deletion for subchats

### DIFF
--- a/convex/subchats.ts
+++ b/convex/subchats.ts
@@ -9,6 +9,7 @@ import {
 } from "./messages";
 import { internal } from "./_generated/api";
 
+// TODO(jordan): Change this to 1 and test pagination in tests once changes to convex-test are in
 const subchatCleanupBatchSize = parseInt(process.env.SUBCHAT_CLEANUP_BATCH_SIZE ?? "128");
 
 export const get = query({


### PR DESCRIPTION
When subchats are created, we cleanup the storage states in the previous subchat We were hitting the read limits [here](https://convexdev.slack.com/archives/C08MJ61008G/p1752136010416289), so I paginated the function. We now cleanup in batch sizes of 128.