### PR TITLE
Merging staging into release

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ can use the Vercel instant rollbacks to prompt old deployments to production.
   - `VITE_AUTH0_CLIENT_ID`
   - `VITE_AUTH0_DOMAIN`
 
-Additionally make sure `CHEF_OAUTH_APP_NAME` is set on your Convex deployment
+Additionally make sure `CONVEX_OAUTH_CLIENT_ID` and `CONVEX_OAUTH_CLIENT_SECRET` is set on your Convex deployment
 (it'll also be in the default Convex project env vars, so you can sync via dashboard).
 
 ### Developing against local big-brain

--- a/convex/convexProjects.ts
+++ b/convex/convexProjects.ts
@@ -317,7 +317,10 @@ async function _connectConvexProjectForMember(
     body: JSON.stringify({
       authn_token: args.accessToken,
       projectId: data.projectId,
-      appName: ensureEnvVar("CHEF_OAUTH_APP_NAME"),
+      oauthApp: {
+        clientId: ensureEnvVar("CONVEX_OAUTH_CLIENT_ID"),
+        clientSecret: ensureEnvVar("CONVEX_OAUTH_CLIENT_SECRET"),
+      },
     }),
   });
   if (!projectDeployKeyResponse.ok) {


### PR DESCRIPTION
The `appName` parameter to the `/authorize` endpoint is being deprecated. We can use the client id an secret for the Chef oauth app (there's one for development, staging, and production) instead.

I updated the environment variables on the production and staging deployment. Developers will need to resync the default project env vars

<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
