### PR TITLE
[API Keys] Allow pro users to use built-in chef tokens when api key is not provided

### DIFF
--- a/app/lib/.server/chat.ts
+++ b/app/lib/.server/chat.ts
@@ -207,7 +207,7 @@ export async function chatAction({ request }: ActionFunctionArgs) {
   }
 }
 
-// Returns whether or not the user has an API key set
+// Returns whether or not the user has an API key set for a given provider
 function hasApiKeySetForProvider(
   userApiKey:
     | { preference: 'always' | 'quotaExhausted'; value?: string; openai?: string; xai?: string; google?: string }


### PR DESCRIPTION
We were getting some complaints on [discord](https://discord.com/channels/1019350475847499849/1399469900631642123) that users with other API keys set were not able to use the built-in chef tokens when API keys were set for another provider.

This fixes the issue by checking if the user has an API key set for the current provider they have selected instead of any provider.