### PR TITLE
Choose `latest` convex binary in evals

### DIFF
--- a/test-kitchen/convexBackend.ts
+++ b/test-kitchen/convexBackend.ts
@@ -18,7 +18,7 @@ const admin_key =
 
 const convexRelease = fetch('https://api.github.com/repos/get-convex/convex-backend/releases')
   .then((r) => r.json())
-  .then((releases) => releases.filter((r: any) => r.prerelease === false)[0]);
+  .then((releases) => releases.find((release: any) => release.prerelease === false));
 
 const downloadBinaryMutex = new Mutex();
 const portMutex = new Mutex();


### PR DESCRIPTION
We guarantee that the version marked as `latest` will always have the precompiled binary for all platforms. Thus, we should only use these and not prerelease version.

Fixes a bug where a platform's binary could be missing.