### PR TITLE
Set reasoning effort for GPT-5

### DIFF
--- a/app/lib/.server/llm/provider.ts
+++ b/app/lib/.server/llm/provider.ts
@@ -134,7 +134,7 @@ export function getProvider(
       provider = {
         model: openai(model),
         maxTokens: 24576,
-        options: modelChoice === 'gpt-5' ? { openai: { reasoningEffort: 'high' } } : undefined,
+        options: modelChoice === 'gpt-5' ? { openai: { reasoningEffort: 'medium' } } : undefined,
       };
       break;
     }


### PR DESCRIPTION
@jordanhunt22 Is this what you did on your local branch? Weirdly I’m not getting any errors if I set `reasoningEffort` to an invalid value so I’m not sure that I’m doing it correctly

https://ai-sdk.dev/providers/ai-sdk-providers/openai