### PR TITLE
[Bugfix] Remove amazon model slug

### DIFF
--- a/app/lib/.server/llm/provider.ts
+++ b/app/lib/.server/llm/provider.ts
@@ -17,8 +17,6 @@ import { GENERAL_SYSTEM_PROMPT_PRELUDE, ROLE_SYSTEM_PROMPT } from 'chef-agent/pr
 
 const ALLOWED_AWS_REGIONS = ['us-east-1', 'us-east-2', 'us-west-2'];
 
-const BEDROCK_CLAUDE_SONNET_4_0 = 'us.anthropic.claude-sonnet-4-20250514-v1:0';
-
 export type ModelProvider = Exclude<ProviderType, 'Unknown'>;
 type Provider = {
   maxTokens: number;
@@ -33,7 +31,7 @@ type Provider = {
 export function modelForProvider(provider: ModelProvider, modelChoice: string | undefined) {
   if (modelChoice) {
     if (modelChoice === 'claude-sonnet-4-0' && provider === 'Bedrock') {
-      return BEDROCK_CLAUDE_SONNET_4_0;
+      return 'us.anthropic.claude-sonnet-4-20250514-v1:0';
     }
 
     if (modelChoice === 'gpt-5') {
@@ -61,7 +59,7 @@ export function modelForProvider(provider: ModelProvider, modelChoice: string | 
 }
 
 function anthropicMaxTokens(modelChoice: string | undefined) {
-  return modelChoice === 'claude-sonnet-4-0' || modelChoice === BEDROCK_CLAUDE_SONNET_4_0 ? 24576 : 8192;
+  return modelChoice === 'claude-sonnet-4-0' ? 24576 : 8192;
 }
 
 export function getProvider(


### PR DESCRIPTION
The model choice that is passed in will never be the aws slug, so I removed it. I added it in [this](https://github.com/get-convex/chef/pull/820) PR.