### PR TITLE
Add canonical link

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -54,10 +54,6 @@ export const links: LinksFunction = () => [
     rel: 'stylesheet',
     href: 'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap',
   },
-  {
-    rel: 'canonical',
-    href: 'https://chef.convex.dev',
-  },
 ];
 
 const inlineThemeCode = stripIndents`

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,6 +1,6 @@
 import { json } from '@vercel/remix';
 import type { LoaderFunctionArgs } from '@vercel/remix';
-import type { MetaFunction } from '@vercel/remix';
+import type { LinksFunction, MetaFunction } from '@vercel/remix';
 import { ClientOnly } from 'remix-utils/client-only';
 import { Header } from '~/components/header/Header';
 import { Homepage } from '~/components/Homepage.client';
@@ -15,6 +15,13 @@ export const meta: MetaFunction = () => {
     },
   ];
 };
+
+export const links: LinksFunction = () => [
+  {
+    rel: 'canonical',
+    href: 'https://chef.convex.dev/',
+  },
+];
 
 export const loader = async (args: LoaderFunctionArgs) => {
   const url = new URL(args.request.url);


### PR DESCRIPTION
Quick fix, adding a `rel="canonical"` link to ensure that search engines don't index other URLs with the same content (e.g. https://chef.convex.dev/?ref=news.convex.dev) and consolidating the SEO value of any of those links onto the single URL.

From an Ahrefs site audit:
<img width="1113" height="192" alt="image" src="https://github.com/user-attachments/assets/9c473f5a-3031-4321-8387-e4884a06f9d4" />
