### PR TITLE
Reduce eval frequency

### DIFF
--- a/.github/workflows/daily_evals.yml
+++ b/.github/workflows/daily_evals.yml
@@ -2,7 +2,7 @@ name: Daily Evals
 
 on:
   schedule:
-    - cron: '0 */8 * * *' # Run 3 times a day
+    - cron: '0 0 * * *' # Run once a day at midnight UTC
   workflow_dispatch: # Allow manual triggering
 
 jobs:


### PR DESCRIPTION
Evals would previously run 3 times/day. We now have evals on every release PR and don't need to run them as frequently. We now just run evals once/day at midnight UTC.