### PR TITLE
Clean up anthropic caching

### DIFF
--- a/app/lib/.server/llm/convex-agent.ts
+++ b/app/lib/.server/llm/convex-agent.ts
@@ -133,6 +133,16 @@ export async function convexAgent(args: {
     };
   }
 
+  if (modelProvider === 'Anthropic') {
+    messagesForDataStream[messagesForDataStream.length - 1].providerOptions = {
+      anthropic: {
+        cacheControl: {
+          type: 'ephemeral',
+        },
+      },
+    };
+  }
+
   const dataStream = createDataStream({
     execute(dataStream) {
       const result = streamText({


### PR DESCRIPTION
Since [this](https://www.anthropic.com/news/token-saving-updates) released, we only need to add a cache point at the end of the messages we send.

This allows us to remove the hack we did earlier. I tested locally and confirmed that we still are putting/reading tokens from the cache.