### PR TITLE
Fix React StrictMode chat ID initialization error

### DIFF
--- a/app/components/Homepage.client.tsx
+++ b/app/components/Homepage.client.tsx
@@ -1,9 +1,9 @@
 import { Chat } from './chat/Chat';
 import { ChefAuthProvider } from './chat/ChefAuthWrapper';
-import { useRef } from 'react';
+import { useRef, useMemo } from 'react';
 import { useConvexChatHomepage } from '~/lib/stores/startup';
 import { Toaster } from '~/components/ui/Toaster';
-import { setPageLoadChatId } from '~/lib/stores/chatId';
+import { setPageLoadChatId, getPageLoadChatId } from '~/lib/stores/chatId';
 import type { Message } from '@ai-sdk/react';
 import type { PartCache } from '~/lib/hooks/useMessageParser';
 import { UserProvider } from '~/components/UserProvider';
@@ -12,14 +12,22 @@ export function Homepage() {
   // Set up a temporary chat ID early in app initialization. We'll
   // eventually replace this with a slug once we receive the first
   // artifact from the model if the user submits a prompt.
-  const initialId = useRef(crypto.randomUUID());
-  setPageLoadChatId(initialId.current);
+  const initialId = useMemo(() => {
+    // Check if a chat ID already exists (e.g., from React StrictMode double-render)
+    const existing = getPageLoadChatId();
+    if (existing) {
+      return existing;
+    }
+    const id = crypto.randomUUID();
+    setPageLoadChatId(id);
+    return id;
+  }, []);
   // NB: On this path, we render `ChatImpl` immediately.
   return (
     <>
       <ChefAuthProvider redirectIfUnauthenticated={false}>
         <UserProvider>
-          <ChatWrapper initialId={initialId.current} />
+          <ChatWrapper initialId={initialId} />
         </UserProvider>
       </ChefAuthProvider>
       <Toaster />

--- a/app/lib/stores/chatId.ts
+++ b/app/lib/stores/chatId.ts
@@ -15,6 +15,10 @@ import { atom, computed, map } from 'nanostores';
  */
 const pageLoadChatId = atom<string | undefined>(undefined);
 
+export function getPageLoadChatId() {
+  return pageLoadChatId.get();
+}
+
 export function setPageLoadChatId(chatId: string) {
   const existing = pageLoadChatId.get();
   if (existing !== undefined && existing !== chatId) {


### PR DESCRIPTION
  - Add getPageLoadChatId() to check for existing chat IDs
  - Use useMemo instead of useRef to ensure single initialization
  - Prevent duplicate chat ID generation during StrictMode double-render

<!-- Describe your PR here. -->
  ## Summary
  Fixes an error where `pageLoadChatId` was being set multiple times during component initialization, causing
  the app to crash with "pageLoadChatId already set" error.

  ## Problem
  In React StrictMode (development), components are intentionally double-rendered to detect side effects. The
  Homepage component was calling `setPageLoadChatId()` directly in the component body via `useRef`, causing it
  to generate and attempt to set different UUIDs on each render.

  ## Solution
  - Added `getPageLoadChatId()` helper to check for existing chat IDs
  - Wrapped chat ID initialization in `useMemo` to ensure it only runs once
  - Check for existing chat ID before generating a new one, preventing conflicts during React's double-render in
   development

  ## Test Plan
  - [x] Verified the error no longer occurs in development mode with React StrictMode enabled
  - [x] Confirmed chat initialization works correctly on first page load
  - [x] Tested that chat IDs remain consistent across component re-renders<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
