### PR TITLE
Add disclaimer for production use

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ Visit our [documentation](https://docs.convex.dev/chef) to learn more about Chef
 The easiest way to build with Chef is through our hosted [webapp](https://chef.convex.dev), which includes a generous free tier. If you want to
 run Chef locally, you can follow the guide below.
 
-### Disclaimer
+### Disclaimer: Hosting Chef forks
 
-Chef is provided as-is, using an authentication configuration specific to Convex. If you are planning on developing a fork of Chef for production use or re-distribution, your fork will need to replace the existing authentication system.
+Chef is provided as-is, using an authentication configuration specific to Convex's internal control plane that manages user accounts.
 
-In this scenario, we'd recommend:
-- Replacing Chef's authentication system with your own
-- Having your fork use Convex's be an [OAuth Application](https://docs.convex.dev/platform-apis/oauth-applications) using Conve's [Platform APIs](https://docs.convex.dev/platform-apis)
+If you are planning on developing a fork of Chef for production use or re-distribution, your fork will need to replace the existing authentication system with your own. We recommend using the [OAuth Authorization Code Grant](https://docs.convex.dev/platform-apis/oauth-applications#implementing-oauth) flow to authorize access to Convex teams or projects. [Read more about available Platform APIs](https://docs.convex.dev/platform-apis).
+
+Chef is still easy to use for local development without changes, read on for instructions for using Chef locally.
 
 ### Running Locally
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Chef is provided as-is, using an authentication configuration specific to Convex
 
 If you are planning on developing a fork of Chef for production use or re-distribution, your fork will need to replace the existing authentication system with your own. We recommend using the [OAuth Authorization Code Grant](https://docs.convex.dev/platform-apis/oauth-applications#implementing-oauth) flow to authorize access to Convex teams or projects. [Read more about available Platform APIs](https://docs.convex.dev/platform-apis).
 
-Chef is still easy to use for local development without changes, read on for instructions for using Chef locally.
+Chef is easy to use for local development without changes. Read on for instructions for using Chef locally.
 
 ### Running Locally
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ Visit our [documentation](https://docs.convex.dev/chef) to learn more about Chef
 The easiest way to build with Chef is through our hosted [webapp](https://chef.convex.dev), which includes a generous free tier. If you want to
 run Chef locally, you can follow the guide below.
 
+### Disclaimer
+
+Chef is provided as-is, using an authentication configuration specific to Convex. If you are planning on developing a fork of Chef for production use or re-distribution, your fork will need to replace the existing authentication system.
+
+In this scenario, we'd recommend:
+- Replacing Chef's authentication system with your own
+- Having your fork use Convex's be an [OAuth Application](https://docs.convex.dev/platform-apis/oauth-applications) using Conve's [Platform APIs](https://docs.convex.dev/platform-apis)
+
 ### Running Locally
 
 Note: This will use the hosted Convex control plane to provision Convex projects. However, Chef tokens used in this enviroment will not count towards usage in your Convex account.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Visit our [documentation](https://docs.convex.dev/chef) to learn more about Chef
 The easiest way to build with Chef is through our hosted [webapp](https://chef.convex.dev), which includes a generous free tier. If you want to
 run Chef locally, you can follow the guide below.
 
-### Disclaimer: Hosting Chef forks
+[!IMPORTANT]
 
 Chef is provided as-is, using an authentication configuration specific to Convex's internal control plane that manages user accounts.
 


### PR DESCRIPTION
Adds clarification that to use Chef in a live environment, you need to make changes to the authentication system.
