### PR TITLE
use convexMemberId for launchdarkly context identifier

### DIFF
--- a/app/components/UserProvider.tsx
+++ b/app/components/UserProvider.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { setExtra, setUser } from '@sentry/remix';
-import { useConvex } from 'convex/react';
+import { useConvex, useQuery } from 'convex/react';
 import { useConvexSessionIdOrNullOrLoading, getConvexAuthToken } from '~/lib/stores/sessionId';
 import { useChatId } from '~/lib/stores/chatId';
 import { setProfile } from '~/lib/stores/profile';
@@ -19,6 +19,7 @@ export const UserProvider = withLDProvider<any>({
 function UserProviderInner({ children }: { children: React.ReactNode }) {
   const launchdarkly = useLDClient();
   const { user } = useAuth();
+  const convexMemberId = useQuery(api.sessions.convexMemberId);
   const sessionId = useConvexSessionIdOrNullOrLoading();
   const chatId = useChatId();
   const convex = useConvex();
@@ -39,11 +40,11 @@ function UserProviderInner({ children }: { children: React.ReactNode }) {
     async function updateProfile() {
       if (user) {
         launchdarkly?.identify({
-          key: user.id ?? '',
+          key: convexMemberId ?? '',
           email: user.email ?? '',
         });
         setUser({
-          id: user.id,
+          id: convexMemberId ?? '',
           username: user.firstName ? (user.lastName ? `${user.firstName} ${user.lastName}` : user.firstName) : '',
           email: user.email ?? undefined,
         });
@@ -81,7 +82,7 @@ function UserProviderInner({ children }: { children: React.ReactNode }) {
     }
     void updateProfile();
     // Including tokenValue is important here even though it's not a direct dependency
-  }, [launchdarkly, user, convex, tokenValue]);
+  }, [launchdarkly, user, convex, tokenValue, convexMemberId]);
 
   return children;
 }

--- a/convex/sessions.ts
+++ b/convex/sessions.ts
@@ -191,6 +191,19 @@ async function getOrCreateCurrentMember(ctx: MutationCtx) {
   });
 }
 
+export const convexMemberId = query(async (ctx) => {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity) {
+    return null;
+  }
+  const existingMember = await ctx.db
+    .query("convexMembers")
+    .withIndex("byConvexMemberId", (q) => q.eq("convexMemberId", identity.convex_member_id as string))
+    .first();
+
+  return existingMember?.convexMemberId;
+});
+
 export async function getCurrentMember(ctx: QueryCtx) {
   const identity = await ctx.auth.getUserIdentity();
   if (!identity) {


### PR DESCRIPTION
Instead of using the auth user id, let's use the convex member id when identifying users with launchdarkly. This will reduce our Client-side mau usage in LD because we use the convex member id as the identifier in the dashboard