### PR TITLE
Show SSO-specific error message instead of generic 403

### DIFF
--- a/convex/convexProjects.ts
+++ b/convex/convexProjects.ts
@@ -274,7 +274,9 @@ async function _connectConvexProjectForMember(
     const text = await response.text();
     const defaultProvisioningError = new ConvexError({
       code: "ProvisioningError",
-      message: `Failed to create project: ${response.status}`,
+      message: text.includes("SSORequired")
+        ? "You must log in with Single Sign-on to access this team."
+        : `Failed to create project: ${response.status}`,
       details: text,
     });
     if (response.status !== 400) {
@@ -327,7 +329,9 @@ async function _connectConvexProjectForMember(
     const text = await projectDeployKeyResponse.text();
     throw new ConvexError({
       code: "ProvisioningError",
-      message: `Failed to create project deploy key: ${projectDeployKeyResponse.status}`,
+      message: text.includes("SSORequired")
+        ? "You must log in with Single Sign-on to access this team."
+        : `Failed to create project deploy key: ${projectDeployKeyResponse.status}`,
       details: text,
     });
   }

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -643,6 +643,8 @@ async function tryDeleteProject(args: {
       const error = JSON.parse(text);
       if (error.code === "TeamNotFound") {
         return { kind: "error", error: `Team not found: ${teamSlug}` };
+      } else if (error.code === "SSORequired") {
+        return { kind: "error", error: `You must log in with Single Sign-on to access this team.` };
       }
       return { kind: "error", error: `Failed to fetch team projects: ${projectsResponse.statusText} ${text}` };
     } catch (_e) {
@@ -663,7 +665,12 @@ async function tryDeleteProject(args: {
 
     if (!response.ok) {
       const text = await response.text();
-      return { kind: "error", error: `Failed to delete project: ${response.statusText} ${text}` };
+      return {
+        kind: "error",
+        error: text.includes("SSORequired")
+          ? `You must log in with Single Sign-on to delete this project.`
+          : `Failed to delete project: ${response.statusText} ${text}`,
+      };
     }
   }
 


### PR DESCRIPTION
If the response indicates that logging in with SSO is required, show a more specific error message

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
