### PR TITLE
Add bedrock support for sonnet 4.5 and 4.6

### DIFF
--- a/app/components/chat/Chat.tsx
+++ b/app/components/chat/Chat.tsx
@@ -198,7 +198,7 @@ export const Chat = memo(
           [K in ModelSelection]: { providerName: ModelProvider; apiKeyField: 'value' | 'openai' | 'xai' | 'google' };
         } = {
           auto: { providerName: 'anthropic', apiKeyField: 'value' },
-          'claude-4-sonnet': { providerName: 'anthropic', apiKeyField: 'value' },
+          'claude-4.6-sonnet': { providerName: 'anthropic', apiKeyField: 'value' },
           'claude-4.5-sonnet': { providerName: 'anthropic', apiKeyField: 'value' },
           'gpt-4.1': { providerName: 'openai', apiKeyField: 'openai' },
           'gpt-5': { providerName: 'openai', apiKeyField: 'openai' },
@@ -299,16 +299,17 @@ export const Chat = memo(
         if (modelSelection === 'auto') {
           const providers: ProviderType[] = anthropicProviders;
           modelProvider = providers[retries.numFailures % providers.length];
-          modelChoice = 'claude-sonnet-4-0';
+          modelChoice = 'claude-sonnet-4-6';
         } else if (modelSelection === 'claude-3-5-haiku') {
           modelProvider = 'Anthropic';
           modelChoice = 'claude-3-5-haiku-latest';
-        } else if (modelSelection === 'claude-4-sonnet') {
+        } else if (modelSelection === 'claude-4.6-sonnet') {
           const providers: ProviderType[] = anthropicProviders;
           modelProvider = providers[retries.numFailures % providers.length];
-          modelChoice = 'claude-sonnet-4-0';
+          modelChoice = 'claude-sonnet-4-6';
         } else if (modelSelection === 'claude-4.5-sonnet') {
-          modelProvider = 'Anthropic';
+          const providers: ProviderType[] = anthropicProviders;
+          modelProvider = providers[retries.numFailures % providers.length];
           modelChoice = 'claude-sonnet-4-5';
         } else if (modelSelection === 'grok-3-mini') {
           modelProvider = 'XAI';

--- a/app/components/chat/ModelSelector.tsx
+++ b/app/components/chat/ModelSelector.tsx
@@ -76,8 +76,8 @@ export const models: Partial<
     recommended: true,
     provider: 'auto',
   },
-  'claude-4-sonnet': {
-    name: 'Claude 4 Sonnet',
+  'claude-4.6-sonnet': {
+    name: 'Claude Sonnet 4.6',
     provider: 'anthropic',
     recommended: true,
     requireKey: false,

--- a/app/lib/.server/chat.ts
+++ b/app/lib/.server/chat.ts
@@ -89,7 +89,8 @@ export async function chatAction({ request }: ActionFunctionArgs) {
     (body.modelChoice &&
       body.modelChoice !== 'claude-sonnet-4-0' &&
       body.modelChoice !== 'gpt-5' &&
-      body.modelChoice !== 'claude-sonnet-4-5')
+      body.modelChoice !== 'claude-sonnet-4-5' &&
+      body.modelChoice !== 'claude-sonnet-4-6')
   ) {
     useUserApiKey = true;
   }
@@ -178,9 +179,9 @@ export async function chatAction({ request }: ActionFunctionArgs) {
       // Only set the requested model choice if we're using a user API key or Claude 4 Sonnet/GPT-5
       modelChoice:
         userApiKey ||
-        body.modelChoice === 'claude-sonnet-4-0' ||
         body.modelChoice === 'gpt-5' ||
-        body.modelChoice === 'claude-sonnet-4-5'
+        body.modelChoice === 'claude-sonnet-4-5' ||
+        body.modelChoice === 'claude-sonnet-4-6'
           ? body.modelChoice
           : undefined,
       userApiKey,

--- a/app/lib/.server/chat.ts
+++ b/app/lib/.server/chat.ts
@@ -82,7 +82,7 @@ export async function chatAction({ request }: ActionFunctionArgs) {
   let useUserApiKey = false;
 
   // Use the user's API key if they're set to always mode or if they manually set a model.
-  // Sonnet 4 can be used with the default API key since it has the same pricing as Sonnet 3.5
+  // Sonnet 4.5 and 4.6 can be used with the default API key since it has the same pricing
   // GPT-5 can be used with our own API key since it has the same pricing as Gemini 2.5 Pro
   if (
     body.userApiKey?.preference === 'always' ||

--- a/app/lib/.server/llm/provider.ts
+++ b/app/lib/.server/llm/provider.ts
@@ -36,6 +36,14 @@ export function modelForProvider(provider: ModelProvider, modelChoice: string | 
       return 'us.anthropic.claude-sonnet-4-20250514-v1:0';
     }
 
+    if (modelChoice === 'claude-sonnet-4-6' && provider === 'Bedrock') {
+      return 'anthropic.claude-sonnet-4-6';
+    }
+
+    if (modelChoice === 'claude-sonnet-4-5' && provider === 'Bedrock') {
+      return 'anthropic.claude-sonnet-4-5-20250929-v1:0';
+    }
+
     if (modelChoice === 'gpt-5') {
       return 'gpt-5';
     }
@@ -61,7 +69,7 @@ export function modelForProvider(provider: ModelProvider, modelChoice: string | 
 }
 
 function anthropicMaxTokens(modelChoice: string | undefined) {
-  return modelChoice === 'claude-sonnet-4-0' || modelChoice === 'claude-sonnet-4-5' ? 24576 : 8192;
+  return modelChoice === 'claude-sonnet-4-5' || modelChoice === 'claude-sonnet-4-6' ? 24576 : 8192;
 }
 
 export function getProvider(

--- a/app/lib/.server/llm/provider.ts
+++ b/app/lib/.server/llm/provider.ts
@@ -52,9 +52,9 @@ export function modelForProvider(provider: ModelProvider, modelChoice: string | 
   }
   switch (provider) {
     case 'Anthropic':
-      return getEnv('ANTHROPIC_MODEL') || 'claude-3-5-sonnet-20241022';
+      return getEnv('ANTHROPIC_MODEL') || 'claude-sonnet-4-6';
     case 'Bedrock':
-      return getEnv('AMAZON_BEDROCK_MODEL') || 'us.anthropic.claude-3-5-sonnet-20241022-v2:0';
+      return getEnv('AMAZON_BEDROCK_MODEL') || 'anthropic.claude-sonnet-4-6';
     case 'OpenAI':
       return getEnv('OPENAI_MODEL') || 'gpt-4.1';
     case 'XAI':

--- a/app/lib/common/apiKey.ts
+++ b/app/lib/common/apiKey.ts
@@ -17,7 +17,7 @@ export function hasApiKeySet(
       }
       return !!apiKey.value?.trim();
     case 'claude-3-5-haiku':
-    case 'claude-4-sonnet':
+    case 'claude-4.6-sonnet':
     case 'claude-4.5-sonnet':
       return !!apiKey.value?.trim();
     case 'gpt-4.1':

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -27,7 +27,7 @@ export function backoffTime(numFailures: number) {
 export type ModelSelection =
   | 'auto'
   | 'claude-3-5-haiku'
-  | 'claude-4-sonnet'
+  | 'claude-4.6-sonnet'
   | 'claude-4.5-sonnet'
   | 'gpt-4.1'
   | 'gpt-4.1-mini'

--- a/test-kitchen/initialGeneration.eval.ts
+++ b/test-kitchen/initialGeneration.eval.ts
@@ -44,9 +44,9 @@ net.setDefaultAutoSelectFamily(true);
 
 if (process.env.ANTHROPIC_API_KEY) {
   chefEval({
-    name: 'claude-4-sonnet',
-    model_slug: 'claude-sonnet-4-20250514',
-    ai: anthropic('claude-sonnet-4-20250514'),
+    name: 'claude-4.6-sonnet',
+    model_slug: 'claude-sonnet-4-6',
+    ai: anthropic('claude-sonnet-4-6'),
     maxTokens: 16384,
   });
   chefEval({


### PR DESCRIPTION
Adds support for sonnet 4.6 and make it the default.

Removes support for sonnet 4, since it is now a pretty old model.

This will now send all traffic to bedrock.